### PR TITLE
CompatHelper: bump compat for Boltz to 0.2 for package ImageNet, (kee…

### DIFF
--- a/examples/ImageNet/Project.toml
+++ b/examples/ImageNet/Project.toml
@@ -25,7 +25,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Augmentor = "0.6"
-Boltz = "0.1"
+Boltz = "0.1, 0.2"
 CUDA = "3, 4"
 Configurations = "0.17"
 FLoops = "0.2"


### PR DESCRIPTION
…p existing compat)