### PR TITLE
DOCFIX: LayerNorm's affine default value was incorrectly noted as 'false' in doc.

### DIFF
--- a/src/layers/normalize.jl
+++ b/src/layers/normalize.jl
@@ -516,7 +516,7 @@ end
 
 @doc doc"""
     LayerNorm(shape::NTuple{N, Int}, activation=identity; epsilon=1f-5, dims=Colon(),
-              affine::Bool=false, init_bias=zeros32, init_scale=ones32,)
+              affine::Bool=true, init_bias=zeros32, init_scale=ones32,)
 
 Computes mean and standard deviation over the whole input array, and uses these to
 normalize the whole array. Optionally applies an elementwise affine transformation
@@ -529,6 +529,10 @@ y = \frac{x - \mathbb{E}[x]}{\sqrt{Var[x] + \epsilon}} * \gamma + \beta
 ```
 
 where ``\gamma`` & ``\beta`` are trainable parameters if `affine=true`.
+
+> As of v0.5.0, the doc used to say `affine::Bool=false`, but the code actually had
+> `affine::Bool=true` as the default. Now the doc reflects the code, so please check
+> whether your assumptions about the default (if made) were invalid.
 
 ## Arguments
 

--- a/src/layers/normalize.jl
+++ b/src/layers/normalize.jl
@@ -530,9 +530,11 @@ y = \frac{x - \mathbb{E}[x]}{\sqrt{Var[x] + \epsilon}} * \gamma + \beta
 
 where ``\gamma`` & ``\beta`` are trainable parameters if `affine=true`.
 
-> As of v0.5.0, the doc used to say `affine::Bool=false`, but the code actually had
-> `affine::Bool=true` as the default. Now the doc reflects the code, so please check
-> whether your assumptions about the default (if made) were invalid.
+!!! note
+
+    As of v0.5.0, the doc used to say `affine::Bool=false`, but the code actually had
+    `affine::Bool=true` as the default. Now the doc reflects the code, so please check
+    whether your assumptions about the default (if made) were invalid.
 
 ## Arguments
 


### PR DESCRIPTION
DOCFIX: The LayerNorm doc originally said default for `affine` is `false`
but the code says it is `true`. So this commit changes the doc to reflect 
the code. Also added a note in the doc about the change.

PS: I thought I was using LayerNorm without scale+bias applied to the output, 
but was surprised to find those parameters when I looked at what Lux.setup
was giving me. Then I noticed the discrepancy between the code and the docs.