### PR TITLE
Fix link to documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ st_opt, ps = Optimisers.update(st_opt, ps, gs)
 
 ## Examples
 
-Look in the [examples](/examples/) directory for self-contained usage examples. The [documentation](https://lux.csail.mit.edu/dev) has examples sorted into proper categories.
+Look in the [examples](/examples/) directory for self-contained usage examples. The [documentation](https://lux.csail.mit.edu) has examples sorted into proper categories.
 
 ## Ecosystem
 


### PR DESCRIPTION
Dear Lux devs,

In the readme, the link to the documention URL https://lux.csail.mit.edu/dev yields a 404 "page not found" error.

I replaced it by https://lux.csail.mit.edu.