### PR TITLE
Add `outputsize` for `Chain`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lux"
 uuid = "b2108857-7c20-44ae-9111-449ecde12c47"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.5.18"
+version = "0.5.19"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -66,7 +66,7 @@ LinearAlgebra = "1.9"
 Logging = "1.9"
 LuxAMDGPU = "0.2.2"
 LuxCUDA = "0.3.2"
-LuxCore = "0.1.8"
+LuxCore = "0.1.11"
 LuxDeviceUtils = "0.1.14"
 LuxLib = "0.3.10"
 LuxTestUtils = "0.1.15"

--- a/src/layers/containers.jl
+++ b/src/layers/containers.jl
@@ -500,6 +500,8 @@ Base.length(c::Chain) = length(c.layers)
 Base.lastindex(c::Chain) = lastindex(c.layers)
 Base.firstindex(c::Chain) = firstindex(c.layers)
 
+outputsize(c::Chain) = outputsize(c.layers[end])
+
 """
     Maxout(layers...)
     Maxout(; layers...)

--- a/test/layers/containers_tests.jl
+++ b/test/layers/containers_tests.jl
@@ -242,6 +242,7 @@ end
         x = rand(Float32, 10, 1) |> aType
         y, _ = layer(x, ps, st)
         @test size(y) == (1, 1)
+        @test Lux.outputsize(layer) == (1,)
 
         @jet layer(x, ps, st)
         __f = (x, ps) -> sum(first(layer(x, ps, st)))
@@ -267,6 +268,7 @@ end
         x = rand(Float32, 10, 1) |> aType
         y, _ = layer(x, ps, st)
         @test size(y) == (2, 1)
+        @test Lux.outputsize(layer) == (2,)
 
         @jet layer(x, ps, st)
         __f = (x, ps) -> sum(first(layer(x, ps, st)))
@@ -280,6 +282,7 @@ end
         x = rand(Float32, 10, 1) |> aType
         y, _ = layer(x, ps, st)
         @test size(y) == (2, 1)
+        @test Lux.outputsize(layer) == (2,)
 
         @jet layer(x, ps, st)
         __f = (x, ps) -> sum(first(layer(x, ps, st)))
@@ -293,6 +296,7 @@ end
         x = rand(Float32, 10, 1) |> aType
         y, _ = layer(x, ps, st)
         @test size(y) == (5, 1)
+        @test Lux.outputsize(layer) == (5,)
 
         @jet layer(x, ps, st)
         __f = (x, ps) -> sum(first(layer(x, ps, st)))


### PR DESCRIPTION
For `PairwiseFusion`, `Chain` & `Maxout`, I think I have the correct definition, but I'm not sure how to approach `Parallel` and `SkipConnection`.

Should we add `x` as an argument to `outputsize` and call `connection(l(x) for l in layers)`?

I was thinking that if we have nesting we need to define the `outputsize` recursively, so I was wondering if it would make sense to have a way to define how the connection operates on outputsizes, and maybe have dispatched for more common functions like `vcat` and `+`.

Edit: I think it would be better to first add just the simple cases in to unblock https://github.com/JuliaSymbolics/Symbolics.jl/pull/1054 and then the more complicated cases can be added in a separate PR.