### PR TITLE
LuxSimpleChainsExt: specify rng when initializing

### DIFF
--- a/ext/LuxSimpleChainsExt.jl
+++ b/ext/LuxSimpleChainsExt.jl
@@ -66,8 +66,8 @@ end
 
 __to_simplechains_adaptor(layer) = throw(SimpleChainsModelConversionError(layer))
 
-function Lux.initialparameters(::AbstractRNG, layer::SimpleChainsLayer)
-    return (; params=Array(SimpleChains.init_params(layer.layer)))
+function Lux.initialparameters(rng::AbstractRNG, layer::SimpleChainsLayer)
+    return (; params=Array(SimpleChains.init_params(layer.layer; rng=rng)))
 end
 
 # Some type-piracy for nicer interaction with NNlib

--- a/ext/LuxSimpleChainsExt.jl
+++ b/ext/LuxSimpleChainsExt.jl
@@ -67,7 +67,7 @@ end
 __to_simplechains_adaptor(layer) = throw(SimpleChainsModelConversionError(layer))
 
 function Lux.initialparameters(rng::AbstractRNG, layer::SimpleChainsLayer)
-    return (; params=Array(SimpleChains.init_params(layer.layer; rng=rng)))
+    return (; params=Array(SimpleChains.init_params(layer.layer; rng)))
 end
 
 # Some type-piracy for nicer interaction with NNlib

--- a/test/transform/simple_chains_tests.jl
+++ b/test/transform/simple_chains_tests.jl
@@ -9,6 +9,14 @@
 
     simple_chains_model = adaptor(lux_model)
 
+    rng = Random.Xoshiro()
+    ps_rng = []
+    for i ∈ 1:2
+        ps, st = Lux.setup(Lux.replicate(rng), simple_chains_model)
+        push!(ps_rng, ps)
+    end
+    @test allequal(ps_rng)
+
     ps, st = Lux.setup(Random.default_rng(), simple_chains_model)
 
     x = randn(Float32, 28, 28, 1, 1)


### PR DESCRIPTION
Propagates the RNG used by Lux.setup() to SimpleChains via the adaptor. This makes the SimpleChains-backed network setup behavior match that of standard Lux networks.

While this keyword argument is not currently documented in SimpleChains the author has stated in a response to a question whether it should be considered public API that it is.

Closes #554.