### PR TITLE
remove usage of apply in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ ps, st = Lux.setup(rng, model) .|> device
 x = rand(rng, Float32, 128, 2) |> device
 
 # Run the model
-y, st = Lux.apply(model, x, ps, st)
+y, st = model(x, ps, st)
 
 # Gradients
-gs = gradient(p -> sum(Lux.apply(model, x, p, st)[1]), ps)[1]
+gs = gradient(p -> sum(model(x, p, st)[1]), ps)[1]
 
 # Optimization
 st_opt = Optimisers.setup(Optimisers.Adam(0.0001), ps)


### PR DESCRIPTION
The help says this:
```julia
help?> Lux.apply
  apply(model, x, ps, st)

  Simply calls model(x, ps, st)
```
In this case, surely it would be simpler to just call `model(x, ps, st)`?

This makes the change in the README to avoid others wondering "what is `apply` for?". An alternative would be to update the README or docs to explain why `apply` is actually useful.