### PR TITLE
Update style.css to disable 'calt' feature for monospace

### DIFF
--- a/docs/src/.vitepress/theme/style.css
+++ b/docs/src/.vitepress/theme/style.css
@@ -30,21 +30,20 @@ https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/var
     /* Code Snippet font */
     --vp-font-family-mono: JuliaMono-Regular, monospace;
 
+    /* 
+    Disable the 'calt' (contextual alternates, often called ligatures) font feature
+    for monospaced text, which is usually enabled by default. This feature changes
+    the display of character combinations such "-" + ">", and "|" + ">". These can
+    be confusing for beginners, particularly if the font has 'unusual' designs.
+    */
+    font-feature-settings: 'calt' 0;
 }
 
 .mono {
-    /* 
-    Disable contextual alternates (kind of like ligatures but different) in monospace, 
-    which turns `/>` to an up arrow and `|>` (the Julia pipe symbol) to an up arrow as well.  
-    This is pretty bad for Julia folks reading even though copy+paste retains the same text.
-    */
-    font-feature-settings: 'calt' 0;
 
     pre {
         font-family: JuliaMono-Light;
     }
-
-    ;
 
     code {
         font-family: JuliaMono-Light;


### PR DESCRIPTION
Disable  the 'calt' font feature for monospaced fonts.

[Previous discussion issue #514](https://github.com/LuxDL/Lux.jl/issues/514#issuecomment-2045500222)

Before this PR, 'calt' font ligatures are displayed, eg for "|>". Although I (and others) like them, they're considered to be not very beginner friendly:

<img width="714" alt="Screenshot 2024-04-10 at 09 47 16" src="https://github.com/LuxDL/Lux.jl/assets/52289/f265fb7a-dd27-418f-b81c-aabce097ec49">

With this PR:

<img width="734" alt="Screenshot 2024-04-10 at 09 48 11" src="https://github.com/LuxDL/Lux.jl/assets/52289/4b6f799e-c58c-46e4-8975-beaee329c43a">

(See also [this Documenter.jl  issue](https://github.com/JuliaDocs/Documenter.jl/issues/1610))  
