### PR TITLE
Improvement to the `@compact` API

### DIFF
--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,13 @@
+name: Spell Check
+
+on: [pull_request]
+
+jobs:
+  typos-check:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v4
+      - name: Check spelling
+        uses: crate-ci/typos@v1.18.0

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+numer = "numer"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lux"
 uuid = "b2108857-7c20-44ae-9111-449ecde12c47"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.5.34"
+version = "0.5.35"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api/Lux/contrib.md
+++ b/docs/src/api/Lux/contrib.md
@@ -6,8 +6,8 @@ CurrentModule = Lux
 
 All features listed on this page are **experimental** which means:
 
-1. No SemVer Guarantees. We use code here to iterate fast and most users should wait for
-   these features to be marked non-experimental.
+1. No SemVer Guarantees. We use code here to iterate fast. That said, historically we have
+   never broken any code in this module and have always provided a deprecation period.
 2. Expect edge-cases and report them. It will help us move these features out of
    experimental sooner.
 3. None of the features are exported.
@@ -74,8 +74,14 @@ Lux.Experimental.DebugLayer
 Lux.Experimental.share_parameters
 ```
 
+## StatefulLuxLayer
+
+[`Lux.StatefulLuxLayer`](@ref) used to be part of experimental features, but has been
+promoted to stable API. It is now available via `Lux.StatefulLuxLayer`. Change all uses of
+`Lux.Experimental.StatefulLuxLayer` to `Lux.StatefulLuxLayer`.
+
 ## Compact Layer API
 
-```@docs
-Lux.Experimental.@compact
-```
+[`Lux.@compact`](@ref) used to be part of experimental features, but has been promoted to
+stable API. It is now available via `Lux.@compact`. Change all uses of
+`Lux.Experimental.@compact` to `Lux.@compact`.

--- a/docs/src/api/Lux/utilities.md
+++ b/docs/src/api/Lux/utilities.md
@@ -54,6 +54,11 @@ Lux.f64
 StatefulLuxLayer
 ```
 
+## Compact Layer
+
+```@docs
+@compact
+```
 
 ## Truncated Stacktraces
 

--- a/docs/src/introduction/index.md
+++ b/docs/src/introduction/index.md
@@ -48,13 +48,13 @@ standard AD and Optimisers API.
 
 ```@example quickstart
 # Get the device determined by Lux
-device = gpu_device()
+dev = gpu_device()
 
 # Parameter and State Variables
-ps, st = Lux.setup(rng, model) .|> device
+ps, st = Lux.setup(rng, model) .|> dev
 
 # Dummy Input
-x = rand(rng, Float32, 128, 2) |> device
+x = rand(rng, Float32, 128, 2) |> dev
 
 # Run the model
 y, st = Lux.apply(model, x, ps, st)
@@ -74,7 +74,6 @@ st_opt, ps = Optimisers.update(st_opt, ps, gs)
 ```@example custom_compact
 using Lux, Random, Optimisers, Zygote
 # using LuxCUDA, LuxAMDGPU, Metal # Optional packages for GPU support
-import Lux.Experimental: @compact
 using Printf  # For pretty printing
 ```
 

--- a/docs/src/introduction/index.md
+++ b/docs/src/introduction/index.md
@@ -61,8 +61,8 @@ y, st = Lux.apply(model, x, ps, st)
 
 # Gradients
 ## Pullback API to capture change in state
-(l, st_), pb = pullback(p -> Lux.apply(model, x, p, st), ps)
-gs = pb((one.(l), nothing))[1]
+(l, st_), pb = pullback(Lux.apply, model, x, ps, st)
+gs = pb((one.(l), nothing))[3]
 
 # Optimization
 st_opt = Optimisers.setup(Adam(0.0001f0), ps)

--- a/docs/src/manual/interface.md
+++ b/docs/src/manual/interface.md
@@ -87,7 +87,7 @@ reconstruction of the parameters and states.
 println("Parameter Length: ", Lux.parameterlength(l), "; State Length: ",
     Lux.statelength(l))
 
-# But still recommened to define these
+# But still recommended to define these
 Lux.parameterlength(l::Linear) = l.out_dims * l.in_dims + l.out_dims
 
 Lux.statelength(::Linear) = 0

--- a/docs/src/manual/interface.md
+++ b/docs/src/manual/interface.md
@@ -20,6 +20,13 @@ First let's set the expectations straight.
     functionality in the core library (and officially supported ones) **must** adhere to
     the interface
 
+!!! tip
+
+    While writing out a custom struct and defining dispatches manually is a good way to
+    understand the interface, it is not the most concise way. We recommend using the
+    [`Lux.@compact`](@ref) macro to define layers which makes handling the states and
+    parameters downright trivial.
+
 ## Layer Interface
 
 ### Singular Layer
@@ -35,8 +42,8 @@ architecture cannot change.
 
 !!! tip
 
-    For people coming from Flux.jl background this might be weird. We recommend checking out
-    [the Flux to Lux migration guide](@ref migrate-from-flux) first before proceeding.
+    For people coming from Flux.jl background, this might be weird. We recommend checking
+    out [the Flux to Lux migration guide](@ref migrate-from-flux) first before proceeding.
 
 ```@example layer_interface
 using Lux, Random

--- a/docs/src/manual/migrate_from_flux.md
+++ b/docs/src/manual/migrate_from_flux.md
@@ -99,7 +99,7 @@ end
 # `A` is not trainable
 Optimisers.trainable(f::FluxLinear) = (B=f.B,)
 
-# Needed so that both `A` and `B` can be transfered between devices
+# Needed so that both `A` and `B` can be transferred between devices
 Flux.@functor FluxLinear
 
 (l::FluxLinear)(x) = l.A * l.B * x

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -59,7 +59,7 @@ const advanced = [
   }
 ];
 
-const thrid_party = [
+const third_party = [
   {
     href: "https://docs.sciml.ai/Overview/stable/showcase/pinngpu/",
     src: "../pinn.gif",
@@ -114,7 +114,7 @@ of them are non-functional and we will try to get them updated.
 
 :::
 
-<Gallery :images="thrid_party" />
+<Gallery :images="third_party" />
 
 
 ::: tip

--- a/examples/DDIM/README.md
+++ b/examples/DDIM/README.md
@@ -11,7 +11,7 @@ The model generates images from Gaussian noises by <em>denoising</em> iterativel
 # Usage
 Install Julia and instantiate `Project.toml`.
 
-Follwoing scripts are tested on a single NVIDIA Tesla T4 instance.
+Following scripts are tested on a single NVIDIA Tesla T4 instance.
 ## Dataset
 Download and extract `Dataset images` from [102 Category Flower Dataset](https://www.robots.ox.ac.uk/~vgg/data/flowers/102/).
 

--- a/examples/GravitationalWaveForm/main.jl
+++ b/examples/GravitationalWaveForm/main.jl
@@ -163,7 +163,7 @@ function compute_waveform(dt::T, soln, mass_ratio, model_params=nothing) where {
         m₁ = mass_ratio * m₂
 
         orbit₁, orbit₂ = one2two(orbit, m₁, m₂)
-        waveform = h_22_strain_two_body(dt, orbit1, mass1, orbit2, mass2)
+        waveform = h_22_strain_two_body(dt, orbit₁, m₁, orbit₂, m₂)
     else
         waveform = h_22_strain_one_body(dt, orbit)
     end
@@ -183,11 +183,11 @@ end
 function RelativisticOrbitModel(u, (p, M, e), t)
     χ, ϕ = u
 
-    number = (p - 2 - 2 * e * cos(χ)) * (1 + e * cos(χ))^2
+    numer = (p - 2 - 2 * e * cos(χ)) * (1 + e * cos(χ))^2
     denom = sqrt((p - 2)^2 - 4 * e^2)
 
-    χ̇ = number * sqrt(p - 6 - 2 * e * cos(χ)) / (M * (p^2) * denom)
-    ϕ̇ = number / (M * (p^(3 / 2)) * denom)
+    χ̇ = numer * sqrt(p - 6 - 2 * e * cos(χ)) / (M * (p^2) * denom)
+    ϕ̇ = numer / (M * (p^(3 / 2)) * denom)
 
     return [χ̇, ϕ̇]
 end
@@ -260,11 +260,11 @@ function ODE_model(u, nn_params, t)
     ## it, however, in general, we should use `st` to store the state of the neural network.
     y = 1 .+ nn_model([first(u)], nn_params)
 
-    number = (1 + e * cos(χ))^2
+    numer = (1 + e * cos(χ))^2
     denom = M * (p^(3 / 2))
 
-    χ̇ = (number / denom) * y[1]
-    ϕ̇ = (number / denom) * y[2]
+    χ̇ = (numer / denom) * y[1]
+    ϕ̇ = (numer / denom) * y[2]
 
     return [χ̇, ϕ̇]
 end

--- a/examples/GravitationalWaveForm/main.jl
+++ b/examples/GravitationalWaveForm/main.jl
@@ -183,11 +183,11 @@ end
 function RelativisticOrbitModel(u, (p, M, e), t)
     χ, ϕ = u
 
-    numer = (p - 2 - 2 * e * cos(χ)) * (1 + e * cos(χ))^2
+    number = (p - 2 - 2 * e * cos(χ)) * (1 + e * cos(χ))^2
     denom = sqrt((p - 2)^2 - 4 * e^2)
 
-    χ̇ = numer * sqrt(p - 6 - 2 * e * cos(χ)) / (M * (p^2) * denom)
-    ϕ̇ = numer / (M * (p^(3 / 2)) * denom)
+    χ̇ = number * sqrt(p - 6 - 2 * e * cos(χ)) / (M * (p^2) * denom)
+    ϕ̇ = number / (M * (p^(3 / 2)) * denom)
 
     return [χ̇, ϕ̇]
 end
@@ -260,11 +260,11 @@ function ODE_model(u, nn_params, t)
     ## it, however, in general, we should use `st` to store the state of the neural network.
     y = 1 .+ nn_model([first(u)], nn_params)
 
-    numer = (1 + e * cos(χ))^2
+    number = (1 + e * cos(χ))^2
     denom = M * (p^(3 / 2))
 
-    χ̇ = (numer / denom) * y[1]
-    ϕ̇ = (numer / denom) * y[2]
+    χ̇ = (number / denom) * y[1]
+    ϕ̇ = (number / denom) * y[2]
 
     return [χ̇, ϕ̇]
 end

--- a/examples/NeuralODE/main.jl
+++ b/examples/NeuralODE/main.jl
@@ -42,7 +42,23 @@ function loadmnist(batchsize, train_split)
 end
 
 # ## Define the Neural ODE Layer
-#
+# 
+# First we will use the [`@compact`](@ref) macro to define the Neural ODE Layer.
+
+function NeuralODECompact(
+        model::Lux.AbstractExplicitLayer; solver=Tsit5(), tspan=(0.0f0, 1.0f0), kwargs...)
+    return @compact(; model, solver, tspan, kwargs...) do x, p
+        dudt(u, p, t) = vec(model(reshape(u, size(x)), p))
+        ## Note the `p.model` here
+        prob = ODEProblem(ODEFunction{false}(dudt), vec(x), tspan, p.model)
+        return solve(prob, solver; kwargs...)
+    end
+end
+
+# We recommend using the compact macro for creating custom layers. The below implementation
+# exists mostly for historical reasons when `@compact` was not part of the stable API. Also,
+# it helps users understand how the layer interface of Lux works.
+
 # The NeuralODE is a ContainerLayer, which stores a `model`. The parameters and states of
 # the NeuralODE are same as those of the underlying model.
 struct NeuralODE{M <: Lux.AbstractExplicitLayer, So, T, K} <:
@@ -154,6 +170,8 @@ function train(model_function; cpu::Bool=false, kwargs...)
     end
 end
 
+train(NeuralODECompact)
+
 train(NeuralODE)
 
 # We can also change the sensealg and train the model! `GaussAdjoint` allows you to use
@@ -173,8 +191,9 @@ train(NeuralODE; sensealg=ReverseDiffAdjoint(), cpu=true)
 
 # ## Alternate Implementation using Stateful Layer
 
-# Starting `v0.5.5`, Lux provides a `Lux.Experimental.StatefulLuxLayer` which can be used
-# to avoid the [`Box`ing of `st`](https://github.com/JuliaLang/julia/issues/15276).
+# Starting `v0.5.5`, Lux provides a [`StatefulLuxLayer`](@ref) which can be used
+# to avoid the [`Box`ing of `st`](https://github.com/JuliaLang/julia/issues/15276). Using
+# the `@compact` API avoids this problem entirely.
 struct StatefulNeuralODE{M <: Lux.AbstractExplicitLayer, So, T, K} <:
        Lux.AbstractExplicitContainerLayer{(:model,)}
     model::M
@@ -189,7 +208,7 @@ function StatefulNeuralODE(
 end
 
 function (n::StatefulNeuralODE)(x, ps, st)
-    st_model = Lux.StatefulLuxLayer(n.model, ps, st)
+    st_model = StatefulLuxLayer(n.model, ps, st)
     dudt(u, p, t) = st_model(u, p)
     prob = ODEProblem{false}(ODEFunction{false}(dudt), x, n.tspan, ps)
     return solve(prob, n.solver; n.kwargs...), st_model.st
@@ -216,6 +235,12 @@ x = gpu_device()(ones(Float32, 28, 28, 1, 3));
 # We avoid the problem entirely by using `StatefulNeuralODE`
 
 @code_warntype model_stateful(x, ps_stateful, st_stateful)
+
+# Finally checking the compact model
+
+model_compact, ps_compact, st_compact = create_model(NeuralODECompact)
+
+@code_warntype model_compact(x, ps_compact, st_compact)
 
 # Note, that we still recommend using this layer internally and not exposing this as the
 # default API to the users.

--- a/examples/NeuralODE/main.jl
+++ b/examples/NeuralODE/main.jl
@@ -236,11 +236,11 @@ x = gpu_device()(ones(Float32, 28, 28, 1, 3));
 
 @code_warntype model_stateful(x, ps_stateful, st_stateful)
 
+# Note, that we still recommend using this layer internally and not exposing this as the
+# default API to the users.
+
 # Finally checking the compact model
 
 model_compact, ps_compact, st_compact = create_model(NeuralODECompact)
 
 @code_warntype model_compact(x, ps_compact, st_compact)
-
-# Note, that we still recommend using this layer internally and not exposing this as the
-# default API to the users.

--- a/examples/SimpleRNN/main.jl
+++ b/examples/SimpleRNN/main.jl
@@ -108,8 +108,7 @@ end
 function SpiralClassifierCompact(in_dims, hidden_dims, out_dims)
     lstm_cell = LSTMCell(in_dims => hidden_dims)
     classifier = Dense(hidden_dims => out_dims, sigmoid)
-    return @compact(; lstm_cell=lstm_cell,
-        classifier=classifier) do x::AbstractArray{T, 3} where {T}
+    return @compact(; lstm_cell, classifier) do x::AbstractArray{T, 3} where {T}
         x_init, x_rest = Iterators.peel(Lux._eachslice(x, Val(2)))
         y, carry = lstm_cell(x_init)
         for x in x_rest

--- a/src/Lux.jl
+++ b/src/Lux.jl
@@ -26,6 +26,10 @@ using PrecompileTools: @recompile_invalidations
                     inputsize, outputsize, update_state, trainmode, testmode, setup, apply,
                     display_name, replicate
     using LuxDeviceUtils: get_device
+
+    # @compact specific
+    using MacroTools: block, combinedef, splitdef
+    using ConstructionBase: ConstructionBase
 end
 
 @reexport using LuxCore, LuxLib, LuxDeviceUtils, WeightInitializers
@@ -56,6 +60,7 @@ include("contrib/contrib.jl")
 
 # Helpful Functionalities
 include("helpers/stateful.jl")
+include("helpers/compact.jl")
 
 # Transform to and from other frameworks
 include("transform/types.jl")
@@ -70,7 +75,8 @@ include("distributed/public_api.jl")
 include("deprecated.jl")
 
 # Layers
-export cpu, gpu
+export cpu, gpu  # deprecated
+
 export Chain, Parallel, SkipConnection, PairwiseFusion, BranchLayer, Maxout, RepeatedLayer
 export Bilinear, Dense, Embedding, Scale
 export Conv, ConvTranspose, CrossCor, MaxPool, MeanPool, GlobalMaxPool, GlobalMeanPool,
@@ -83,6 +89,7 @@ export RNNCell, LSTMCell, GRUCell, Recurrence, StatefulRecurrentCell
 export SamePad, TimeLastIndex, BatchLastIndex
 
 export StatefulLuxLayer
+export @compact, CompactLuxLayer
 
 export f16, f32, f64
 

--- a/src/contrib/contrib.jl
+++ b/src/contrib/contrib.jl
@@ -3,15 +3,12 @@ module Experimental
 import ..Lux
 using ..Lux, LuxCore, LuxDeviceUtils, Random
 using LuxCore: AbstractExplicitLayer, AbstractExplicitContainerLayer
-import ..Lux: _merge, _pairs, initialstates, initialparameters, apply, NAME_TYPE,
-              _getproperty
+import ..Lux: _merge, _pairs, initialstates, initialparameters, apply
 
 using ADTypes: ADTypes
 import ChainRulesCore as CRC
 using ConcreteStructs: @concrete
-import ConstructionBase: constructorof
 using Functors: Functors, fmap, functor
-using MacroTools: block, combinedef, splitdef
 using Markdown: @doc_str
 using Random: AbstractRNG, Random
 using Setfield: Setfield
@@ -21,8 +18,7 @@ include("training.jl")
 include("freeze.jl")
 include("share_parameters.jl")
 include("debug.jl")
-include("stateful.jl")
-include("compact.jl")
+include("deprecated.jl")
 
 end
 

--- a/src/contrib/deprecated.jl
+++ b/src/contrib/deprecated.jl
@@ -1,4 +1,12 @@
-# Deprecated
+macro compact(exs...)
+    Base.depwarn(
+        "Lux.Experimental.@compact` has been promoted out of `Lux.Experimental` and is now \
+         available in `Lux`. In other words this has been deprecated and will be removed \
+         in v0.6. Use `Lux.@compact` instead.",
+        Symbol("@compact"))
+    return Lux.__compact_macro_impl(exs...)
+end
+
 function StatefulLuxLayer(args...; kwargs...)
     Base.depwarn(
         "Lux.Experimental.StatefulLuxLayer` has been promoted out of `Lux.Experimental` \

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -4,7 +4,7 @@
 
 Transfer `x` to CPU.
 
-!!! warning
+!!! danger
 
     This function has been deprecated. Use [`cpu_device`](@ref) instead.
 """
@@ -19,7 +19,7 @@ end
 
 Transfer `x` to GPU determined by the backend set using [`Lux.gpu_backend!`](@ref).
 
-!!! warning
+!!! danger
 
     This function has been deprecated. Use [`gpu_device`](@ref) instead. Using this function
     inside performance critical code will cause massive slowdowns due to type inference
@@ -41,6 +41,10 @@ end
 An easy way to update `TruncatedStacktraces.VERBOSE` without having to load it manually.
 
 Effectively does `TruncatedStacktraces.VERBOSE[] = disable`
+
+!!! danger
+
+    This function is now deprecated and will be removed in v0.6.
 """
 function disable_stacktrace_truncation!(; disable::Bool=true)
     Base.depwarn("`disable_stacktrace_truncation!` is not needed anymore, as \

--- a/src/distributed/public_api.jl
+++ b/src/distributed/public_api.jl
@@ -179,7 +179,7 @@ function __reduce! end
 
 CRC.@non_differentiable reduce!(::Any...)
 
-# syncronize!
+# synchronize!
 """
     synchronize!!(backend::AbstractLuxDistributedBackend, ps; root::Int=0)
 

--- a/src/layers/containers.jl
+++ b/src/layers/containers.jl
@@ -508,7 +508,7 @@ outputsize(c::Chain) = outputsize(c.layers[end])
 This contains a number of internal layers, each of which receives the same input. Its output
 is the elementwise maximum of the the internal layers' outputs.
 
-Maxout over linear dense layers satisfies the univeral approximation theorem. See [1].
+Maxout over linear dense layers satisfies the universal approximation theorem. See [1].
 
 See also [`Parallel`](@ref) to reduce with other operators.
 

--- a/src/layers/normalize.jl
+++ b/src/layers/normalize.jl
@@ -33,8 +33,8 @@ slice and normalises the input accordingly.
   - If `affine=true`, it also applies  a shift and a rescale to the input through to
     learnable per-channel bias and scale parameters.
     
-      + `init_bias`: Controls how the `bias` is initialiazed
-      + `init_scale`: Controls how the `scale` is initialiazed
+      + `init_bias`: Controls how the `bias` is initialized
+      + `init_scale`: Controls how the `scale` is initialized
 
 ## Inputs
 
@@ -167,8 +167,8 @@ end
   - If `affine=true`, it also applies  a shift and a rescale to the input through to
     learnable per-channel bias and scale parameters.
 
-      + `init_bias`: Controls how the `bias` is initialiazed
-      + `init_scale`: Controls how the `scale` is initialiazed
+      + `init_bias`: Controls how the `bias` is initialized
+      + `init_scale`: Controls how the `scale` is initialized
 
 ## Inputs
 
@@ -265,8 +265,8 @@ accordingly.
   - If `affine=true`, it also applies  a shift and a rescale to the input through to
     learnable per-channel bias and scale parameters.
     
-      + `init_bias`: Controls how the `bias` is initialiazed
-      + `init_scale`: Controls how the `scale` is initialiazed
+      + `init_bias`: Controls how the `bias` is initialized
+      + `init_scale`: Controls how the `scale` is initialized
 
 ## Inputs
 
@@ -506,8 +506,8 @@ where ``\gamma`` & ``\beta`` are trainable parameters if `affine=true`.
   - If `affine=true`, it also applies  a shift and a rescale to the input through to
     learnable per-channel bias and scale parameters.
 
-      + `init_bias`: Controls how the `bias` is initialiazed
-      + `init_scale`: Controls how the `scale` is initialiazed
+      + `init_bias`: Controls how the `bias` is initialized
+      + `init_scale`: Controls how the `scale` is initialized
 
 ## Inputs
 

--- a/src/layers/normalize.jl
+++ b/src/layers/normalize.jl
@@ -33,8 +33,8 @@ slice and normalises the input accordingly.
   - If `affine=true`, it also applies  a shift and a rescale to the input through to
     learnable per-channel bias and scale parameters.
     
-      + `init_bias`: Controls how the `bias` is initiliazed
-      + `init_scale`: Controls how the `scale` is initiliazed
+      + `init_bias`: Controls how the `bias` is initialiazed
+      + `init_scale`: Controls how the `scale` is initialiazed
 
 ## Inputs
 
@@ -167,8 +167,8 @@ end
   - If `affine=true`, it also applies  a shift and a rescale to the input through to
     learnable per-channel bias and scale parameters.
 
-      + `init_bias`: Controls how the `bias` is initiliazed
-      + `init_scale`: Controls how the `scale` is initiliazed
+      + `init_bias`: Controls how the `bias` is initialiazed
+      + `init_scale`: Controls how the `scale` is initialiazed
 
 ## Inputs
 
@@ -265,8 +265,8 @@ accordingly.
   - If `affine=true`, it also applies  a shift and a rescale to the input through to
     learnable per-channel bias and scale parameters.
     
-      + `init_bias`: Controls how the `bias` is initiliazed
-      + `init_scale`: Controls how the `scale` is initiliazed
+      + `init_bias`: Controls how the `bias` is initialiazed
+      + `init_scale`: Controls how the `scale` is initialiazed
 
 ## Inputs
 
@@ -506,8 +506,8 @@ where ``\gamma`` & ``\beta`` are trainable parameters if `affine=true`.
   - If `affine=true`, it also applies  a shift and a rescale to the input through to
     learnable per-channel bias and scale parameters.
 
-      + `init_bias`: Controls how the `bias` is initiliazed
-      + `init_scale`: Controls how the `scale` is initiliazed
+      + `init_bias`: Controls how the `bias` is initialiazed
+      + `init_scale`: Controls how the `scale` is initialiazed
 
 ## Inputs
 

--- a/src/transform/flux.jl
+++ b/src/transform/flux.jl
@@ -5,7 +5,7 @@ Convert a Flux Model to Lux Model.
 
 !!! warning
 
-    This always ingores the `active` field of some of the Flux layers. This is almost never
+    This always ignores the `active` field of some of the Flux layers. This is almost never
     going to be supported.
 
 ## Keyword Arguments

--- a/test/distributed/common_distributedtest.jl
+++ b/test/distributed/common_distributedtest.jl
@@ -19,7 +19,7 @@ nworkers = DistributedUtils.total_workers(backend)
 @test rank < nworkers
 
 # Test the communication primitives
-## broacast!
+## broadcast!
 for arrType in (Array, aType)
     sendbuf = (rank == 0) ? arrType(ones(512)) : arrType(zeros(512))
     recvbuf = arrType(zeros(512))

--- a/test/distributed/synchronize_distributedtest.jl
+++ b/test/distributed/synchronize_distributedtest.jl
@@ -80,7 +80,7 @@ gs = DistributedUtils.synchronize!!(backend, gs; root)
 @test all(gs[1][2] .== 1)
 @test all(gs[2] .== 1)
 
-# Miscelleneous
+# Miscellaneous
 x = nothing
 x = DistributedUtils.synchronize!!(backend, x; root)
 @test x === nothing

--- a/test/helpers/compact_tests.jl
+++ b/test/helpers/compact_tests.jl
@@ -180,7 +180,7 @@
                 return w(x .* s)
             end
             expected_string = """@compact(
-                x = randn(32),
+                x = 32-element Vector{Float64},
                 w = Dense(32 => 32),                # 1_056 parameters
             ) do s 
                 return w(x .* s)
@@ -197,8 +197,8 @@
             end
             expected_string = """@compact(
                 w1 = Model(32)(),                   # 1_024 parameters
-                w2 = randn(32, 32),
-                w3 = randn(32),
+                w2 = 32×32 Matrix{Float64},
+                w3 = 32-element Vector{Float64},
             ) do x 
                 return w2 * w1(x)
             end       # Total: 2_080 parameters,

--- a/test/helpers/compact_tests.jl
+++ b/test/helpers/compact_tests.jl
@@ -1,6 +1,5 @@
 @testitem "@compact" setup=[SharedTestSetup] begin
     using ComponentArrays
-    import Lux.Experimental: @compact
 
     rng = get_stable_rng(12345)
 


### PR DESCRIPTION
- [x] Move compact out of experimental
- [x] Update user-facing tutorials/examples to recommend the compact API. Preserve the abstract explicit layer API for advanced users
- [x] Allow passing in the parameters optionally, needed for sciml applications