### PR TITLE
Add missing table of contents entry

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -155,6 +155,9 @@ export default defineConfig({
                             },
                             {
                                 text: 'Medical Image Segmentation', link: 'https://github.com/Dale-Black/ComputerVisionTutorials.jl/'
+                            },
+                            {
+                                text: 'Neural closure models', link: 'https://github.com/agdestein/NeuralClosureTutorials/'
                             }
                         ]
                     }]


### PR DESCRIPTION
This adds a sidebar link to the tutorial entry from #609.