### PR TITLE
Add field access syntax to Chain

### DIFF
--- a/src/layers/containers.jl
+++ b/src/layers/containers.jl
@@ -512,8 +512,6 @@ function Base.getproperty(c::Chain, name::Symbol)
     hasfield(typeof(layers), name) && return getfield(layers, name)
     throw(ArgumentError("$(typeof(c)) has no field or layer $name"))
 end
-end
-
 Base.length(c::Chain) = length(c.layers)
 Base.lastindex(c::Chain) = lastindex(c.layers)
 Base.firstindex(c::Chain) = firstindex(c.layers)

--- a/src/layers/containers.jl
+++ b/src/layers/containers.jl
@@ -512,6 +512,7 @@ function Base.getproperty(c::Chain, name::Symbol)
     hasfield(typeof(layers), name) && return getfield(layers, name)
     throw(ArgumentError("$(typeof(c)) has no field or layer $name"))
 end
+
 Base.length(c::Chain) = length(c.layers)
 Base.lastindex(c::Chain) = lastindex(c.layers)
 Base.firstindex(c::Chain) = firstindex(c.layers)

--- a/src/layers/containers.jl
+++ b/src/layers/containers.jl
@@ -507,13 +507,11 @@ Base.getindex(c::Chain, i::Int) = c.layers[i]
 Base.getindex(c::Chain, i::AbstractArray) = Chain(_index_namedtuple(c.layers, i))
 
 function Base.getproperty(c::Chain, name::Symbol)
-  if hasfield(Chain, name)
-    return getfield(c, name)
-  elseif hasfield(typeof(getfield(c, :layers)), name)
-    return getfield(getfield(c, :layers), name)
-  else
+    hasfield(typeof(c), name) && return getfield(c, name)
+    layers = getfield(c, :layers)
+    hasfield(typeof(layers), name) && return getfield(layers, name)
     throw(ArgumentError("$(typeof(c)) has no field or layer $name"))
-  end
+end
 end
 
 Base.length(c::Chain) = length(c.layers)

--- a/test/layers/containers_tests.jl
+++ b/test/layers/containers_tests.jl
@@ -305,6 +305,21 @@ end
         @test_throws ArgumentError Chain(;
             l1=Dense(10 => 5, sigmoid), d52=Dense(5 => 2, tanh),
             d21=Dense(2 => 1), d2=Dense(2 => 1), disable_optimizations=false)
+
+        @testset "indexing and field access" begin
+            encoder = Chain(Dense(10 => 5, sigmoid), Dense(5 => 2, tanh))
+            decoder = Chain(Dense(2 => 5, tanh), Dense(5 => 10, sigmoid))
+            autoencoder = Chain(; encoder, decoder)
+            @test encoder[1] == encoder.layer_1
+            @test encoder[2] == encoder.layer_2
+            @test autoencoder[1] == autoencoder.encoder
+            @test autoencoder[2] == autoencoder.decoder
+            @test keys(encoder) == (:layer_1, :layer_2)
+            @test keys(autoencoder) == (:encoder, :decoder)
+            @test autoencoder.layers isa NamedTuple
+            @test autoencoder.encoder isa Chain
+            @test_throws ArgumentError autoencoder.layer_1
+        end
     end
 end
 


### PR DESCRIPTION
Make it possible to use `model.layer_i` syntax when `model isa Chain`; as discussed in  #617.