### PR TITLE
Added layer for periodic inputs

### DIFF
--- a/docs/src/api/Lux/layers.md
+++ b/docs/src/api/Lux/layers.md
@@ -94,3 +94,9 @@ WeightNorm
 PixelShuffle
 Upsample
 ```
+
+## SciML Layers
+
+```@docs
+PeriodicEmbedding
+```

--- a/src/Lux.jl
+++ b/src/Lux.jl
@@ -89,7 +89,7 @@ include("deprecated.jl")
 export cpu, gpu  # deprecated
 
 export Chain, Parallel, SkipConnection, PairwiseFusion, BranchLayer, Maxout, RepeatedLayer
-export Bilinear, Dense, Embedding, Scale, Periodic
+export Bilinear, Dense, Embedding, Scale, PeriodicEmbedding
 export Conv, ConvTranspose, CrossCor, MaxPool, MeanPool, GlobalMaxPool, GlobalMeanPool,
        AdaptiveMaxPool, AdaptiveMeanPool, Upsample, PixelShuffle
 export AlphaDropout, Dropout, VariationalHiddenDropout

--- a/src/Lux.jl
+++ b/src/Lux.jl
@@ -89,7 +89,7 @@ include("deprecated.jl")
 export cpu, gpu  # deprecated
 
 export Chain, Parallel, SkipConnection, PairwiseFusion, BranchLayer, Maxout, RepeatedLayer
-export Bilinear, Dense, Embedding, Scale
+export Bilinear, Dense, Embedding, Scale, Periodic
 export Conv, ConvTranspose, CrossCor, MaxPool, MeanPool, GlobalMaxPool, GlobalMeanPool,
        AdaptiveMaxPool, AdaptiveMeanPool, Upsample, PixelShuffle
 export AlphaDropout, Dropout, VariationalHiddenDropout

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -537,12 +537,13 @@ end
     return vec(first(p(reshape(x, :, 1), ps, st))), st
 end
 
-@inline function (p::Periodic)(x::AbstractMatrix, ps, st::NamedTuple)
+@inline function (p::Periodic)(x::AbstractMatrix{T}, ps, st::NamedTuple) where T
+    k = convert.(T, 2π ./ p.periods)
     return (
         vcat(
             view(x, setdiff(axes(x, 1), p.dims), :),
-            sin.(2π ./ p.periods .* view(x, p.dims, :)),
-            cos.(2π ./ p.periods .* view(x, p.dims, :))
+            sin.(k .* view(x, p.dims, :)),
+            cos.(k .* view(x, p.dims, :))
         ),
         st)
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -541,13 +541,13 @@ Lux.initialstates(::AbstractRNG, p::PeriodicEmbedding) = (k = 2 ./ p.periods,)
     return vec(first(p(reshape(x, :, 1), ps, st))), st
 end
 
-@inline function (p::PeriodicEmbedding)(x::AbstractMatrix{T}, ps, st::NamedTuple) where T
+@inline function (p::PeriodicEmbedding)(x::AbstractMatrix, ps, st::NamedTuple)
     other_dims = ChainRulesCore.@ignore_derivatives setdiff(axes(x, 1), p.dims)
     return (
         vcat(
             view(x, other_dims, :),
-            sinpi.(T.(st[:k]) .* view(x, p.dims, :)),
-            cospi.(T.(st[:k]) .* view(x, p.dims, :))
+            sinpi.(st[:k] .* view(x, p.dims, :)),
+            cospi.(st[:k] .* view(x, p.dims, :))
         ),
         st)
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -521,7 +521,7 @@ periodicity.
 ## Inputs
 
   - `x` must be an `AbstractArray` with `issubset(idxs, axes(x, 1))`
-  - `st` must be a `NamedTuple` where `st[:k] = 2 ./ periods`, but on the same device as `x`
+  - `st` must be a `NamedTuple` where `st.k = 2 ./ periods`, but on the same device as `x`
 
 ## Returns
 
@@ -544,9 +544,9 @@ end
     other_idxs = ChainRulesCore.@ignore_derivatives setdiff(axes(x, 1), p.idxs)
     return (
         vcat(
-            view(x, other_idxs, :),
-            sinpi.(st[:k] .* view(x, p.idxs, :)),
-            cospi.(st[:k] .* view(x, p.idxs, :))
+            x[other_idxs, :],
+            sinpi.(st.k .* x[p.idxs, :]),
+            cospi.(st.k .* x[p.idxs, :])
         ),
         st)
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -538,12 +538,12 @@ end
 end
 
 @inline function (p::Periodic)(x::A, ps, st::NamedTuple) where A <:AbstractMatrix
-    k = vec(convert(A, reshape(2π ./ p.periods, :, 1)))
+    k = convert(A, reshape(2π ./ p.periods, :, 1))
     return (
         vcat(
-            x[setdiff(axes(x, 1), p.dims), :],
-            sin.(k .* x[p.dims, :]),
-            cos.(k .* x[p.dims, :])
+            view(x, setdiff(axes(x, 1), p.dims), :),
+            sin.(k .* view(x, p.dims, :)),
+            cos.(k .* view(x, p.dims, :))
         ),
         st)
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -538,12 +538,11 @@ end
 end
 
 @inline function (p::Periodic)(x::A, ps, st::NamedTuple) where A <:AbstractMatrix
-    k = vec(convert(A, reshape(2π ./ p.periods, :, 1)))
     return (
         vcat(
             view(x, setdiff(axes(x, 1), p.dims), :),
-            sin.(k .* view(x, p.dims, :)),
-            cos.(k .* view(x, p.dims, :))
+            sin.(convert(A, reshape(2π ./ p.periods, :, 1)) .* view(x, p.dims, :)),
+            cos.(convert(A, reshape(2π ./ p.periods, :, 1)) .* view(x, p.dims, :))
         ),
         st)
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -539,9 +539,10 @@ end
 
 @inline function (p::Periodic)(x::A, ps, st::NamedTuple) where A <:AbstractMatrix
     k = convert(A, reshape(2 ./ p.periods, :, 1))
+    ChainRulesCore.@ignore_derivatives other_dims = setdiff(axes(x, 1), p.dims)
     return (
         vcat(
-            view(x, setdiff(axes(x, 1), p.dims), :),
+            view(x, other_dims, :),
             sinpi.(k .* view(x, p.dims, :)),
             cospi.(k .* view(x, p.dims, :))
         ),

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -538,11 +538,12 @@ end
 end
 
 @inline function (p::Periodic)(x::A, ps, st::NamedTuple) where A <:AbstractMatrix
+    k = vec(convert(A, reshape(2π ./ p.periods, :, 1)))
     return (
         vcat(
-            view(x, setdiff(axes(x, 1), p.dims), :),
-            sin.(convert(A, reshape(2π ./ p.periods, :, 1)) .* view(x, p.dims, :)),
-            cos.(convert(A, reshape(2π ./ p.periods, :, 1)) .* view(x, p.dims, :))
+            x[setdiff(axes(x, 1), p.dims), :],
+            sin.(k .* x[p.dims, :]),
+            cos.(k .* x[p.dims, :])
         ),
         st)
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -507,11 +507,16 @@ outputsize(e::Embedding) = (e.out_dims,)
 """
     PeriodicEmbedding(idxs, periods)
 
-Create an embedding periodic in some dimensions with specified periods. Dimensions not in
-`idxs` are passed through unchanged, but dimensions in `idxs` are moved to the end of the
+Create an embedding periodic in some inputs with specified periods. Input indices not in
+`idxs` are passed through unchanged, but inputs in `idxs` are moved to the end of the
 output and replaced with their sines, followed by their cosines (scaled appropriately to
 have the specified periods). This smooth embedding preserves phase information and enforces
 periodicity.
+
+For example, `layer = PeriodicEmbedding([2, 3], [3.0, 1.0])` will create a layer periodic in
+the second input with period 3.0 and periodic in the third input with period 1.0. In this
+case, `layer([a, b, c, d], st) == ([a, d, sinpi(2 / 3.0 * b), sinpi(2 / 1.0 * c),
+cospi(2 / 3.0 * b), cospi(2 / 1.0 * c)], st)`.
 
 ## Arguments
 
@@ -528,6 +533,19 @@ periodicity.
   - `AbstractArray` of size `(size(x, 1) + length(idxs), ...)` where `...` are the other
     dimensions of `x`.
   - `st`, unchanged
+
+## Example
+
+```jldoctest
+julia> layer = PeriodicEmbedding([2], [4.0])
+PeriodicEmbedding(idxs = [2], periods = [4.0])
+julia> using Random; rng = Random.seed!(123);
+
+julia> ps, st = Lux.setup(rng, layer)
+(NamedTuple(), (k = [0.5],))
+julia> all(layer([1.1, 2.2, 3.3], ps, st)[1] .== [1.1, 3.3, sinpi(2 / 4.0 * 2.2), cospi(2 / 4.0 * 2.2)])
+true
+```
 """
 @concrete struct PeriodicEmbedding <:AbstractExplicitLayer
     idxs

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -505,7 +505,7 @@ end
 outputsize(e::Embedding) = (e.out_dims,)
 
 """
-    Periodic(dims, periods)
+    PeriodicEmbedding(dims, periods)
 
 Create a layer periodic in `dims` with respective periods `periods`. All other input
 dimensions are passed through unchanged, but `dims` are replaced with their sine and cosine
@@ -527,17 +527,17 @@ dimensions are passed through unchanged, but `dims` are replaced with their sine
     all the cosines.
   - Empty `NamedTuple()`
 """
-@concrete struct Periodic <:AbstractExplicitLayer
+@concrete struct PeriodicEmbedding <:AbstractExplicitLayer
     dims
     periods
 end
 
 
-@inline function (p::Periodic)(x::AbstractVector, ps, st::NamedTuple)
+@inline function (p::PeriodicEmbedding)(x::AbstractVector, ps, st::NamedTuple)
     return vec(first(p(reshape(x, :, 1), ps, st))), st
 end
 
-@inline function (p::Periodic)(x::A, ps, st::NamedTuple) where A <:AbstractMatrix
+@inline function (p::PeriodicEmbedding)(x::A, ps, st::NamedTuple) where A <:AbstractMatrix
     k = convert(A, reshape(2 ./ p.periods, :, 1))
     other_dims = ChainRulesCore.@ignore_derivatives setdiff(axes(x, 1), p.dims)
     return (
@@ -549,10 +549,10 @@ end
         st)
 end
 
-@inline function (p::Periodic)(x::AbstractArray, ps, st::NamedTuple)
+@inline function (p::PeriodicEmbedding)(x::AbstractArray, ps, st::NamedTuple)
     return reshape(first(p(reshape(x, size(x, 1), :), ps, st)), :, size(x)[2:end]...), st
 end
 
-function Base.show(io::IO, p::Periodic)
-    return print(io, "Periodic(dims = ", p.dims, ", periods = ", p.periods, ")")
+function Base.show(io::IO, p::PeriodicEmbedding)
+    return print(io, "PeriodicEmbedding(dims = ", p.dims, ", periods = ", p.periods, ")")
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -538,12 +538,12 @@ end
 end
 
 @inline function (p::Periodic)(x::A, ps, st::NamedTuple) where A <:AbstractMatrix
-    k = convert(A, reshape(2π ./ p.periods, :, 1))
+    k = convert(A, reshape(2 ./ p.periods, :, 1))
     return (
         vcat(
             view(x, setdiff(axes(x, 1), p.dims), :),
-            sin.(k .* view(x, p.dims, :)),
-            cos.(k .* view(x, p.dims, :))
+            sinpi.(k .* view(x, p.dims, :)),
+            cospi.(k .* view(x, p.dims, :))
         ),
         st)
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -528,8 +528,7 @@ periodicity.
 
   - `AbstractArray` of size `(size(x, 1) + length(dims), ...)` where `...` are the other
     dimensions of `x`.
-  - `NamedTuple` with field `k` equal to `st[:k]`, but with elements of the same type as the
-    elements of `x`
+  - `st`, unchanged
 """
 @concrete struct PeriodicEmbedding <:AbstractExplicitLayer
     dims
@@ -544,14 +543,13 @@ end
 
 @inline function (p::PeriodicEmbedding)(x::AbstractMatrix{T}, ps, st::NamedTuple) where T
     other_dims = ChainRulesCore.@ignore_derivatives setdiff(axes(x, 1), p.dims)
-    _st = (k = T.(st[:k]), )
     return (
         vcat(
             view(x, other_dims, :),
-            sinpi.(_st[:k].* view(x, p.dims, :)),
-            cospi.(_st[:k] .* view(x, p.dims, :))
+            sinpi.(T.(st[:k]) .* view(x, p.dims, :)),
+            cospi.(T.(st[:k]) .* view(x, p.dims, :))
         ),
-        _st)
+        st)
 end
 
 @inline function (p::PeriodicEmbedding)(x::AbstractArray, ps, st::NamedTuple)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -537,8 +537,8 @@ end
     return vec(first(p(reshape(x, :, 1), ps, st))), st
 end
 
-@inline function (p::Periodic)(x::AbstractMatrix{T}, ps, st::NamedTuple) where T
-    k = convert.(T, 2π ./ p.periods)
+@inline function (p::Periodic)(x::A, ps, st::NamedTuple) where A <:AbstractMatrix
+    k = vec(convert(A, reshape(2π ./ p.periods, :, 1)))
     return (
         vcat(
             view(x, setdiff(axes(x, 1), p.dims), :),

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -539,7 +539,7 @@ end
 
 @inline function (p::Periodic)(x::A, ps, st::NamedTuple) where A <:AbstractMatrix
     k = convert(A, reshape(2 ./ p.periods, :, 1))
-    ChainRulesCore.@ignore_derivatives other_dims = setdiff(axes(x, 1), p.dims)
+    other_dims = ChainRulesCore.@ignore_derivatives setdiff(axes(x, 1), p.dims)
     return (
         vcat(
             view(x, other_dims, :),

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -83,7 +83,7 @@
                 all(isapprox(
                     layer(x, ps, st)[1][5:8, :, :, :],
                     layer(x .+ [0.0, 12.0, -2π/5, 0.0, 0.0, 0.0], ps, st)[1][5:8, :, :, :];
-                    atol=sqrt(eps(Float64))
+                    atol=sqrt(eps(typeof(first(x))))
                 ))
 
             @jet layer(x, ps, st)

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -70,8 +70,8 @@
             @eval @test_gradients $__f $x gpu_testing=$ongpu atol=1.0f-3 rtol=1.0f-3
         end
 
-        @testset "Periodic" begin
-            layer = Periodic([2, 3], [4.0, π/5])
+        @testset "PeriodicEmbedding" begin
+            layer = PeriodicEmbedding([2, 3], [4.0, π/5])
             __display(layer)
             ps, st = Lux.setup(rng, layer) .|> device
             x = randn(rng, 6, 4, 3, 2) |> aType

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -84,7 +84,7 @@
                 all(isapprox(
                     val[5:8, :, :, :],
                     shifted_val[5:8, :, :, :];
-                    atol=sqrt(eps(typeof(first(x))))
+                    atol=sqrt(eps(typeof(first(val))))
                 ))
 
             @jet layer(x, ps, st)

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -75,14 +75,15 @@
             __display(layer)
             ps, st = Lux.setup(rng, layer) .|> device
             x = randn(rng, 6, 4, 3, 2) |> aType
+            Δx = [0.0, 12.0, -2π/5, 0.0, 0.0, 0.0] |> aType
 
             @test all(
                     layer(x, ps, st)[1][1:4, :, :, :] .==
-                    layer(x .+ [0.0, 12.0, -2π/5, 0.0, 0.0, 0.0], ps, st)[1][1:4, :, :, :]
+                    layer(x .+ Δx, ps, st)[1][1:4, :, :, :]
                     ) &&
                 all(isapprox(
                     layer(x, ps, st)[1][5:8, :, :, :],
-                    layer(x .+ [0.0, 12.0, -2π/5, 0.0, 0.0, 0.0], ps, st)[1][5:8, :, :, :];
+                    layer(x .+ Δx, ps, st)[1][5:8, :, :, :];
                     atol=sqrt(eps(typeof(first(x))))
                 ))
 

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -87,7 +87,7 @@
                     atol = 5 * eps(Float32)
                 ))
 
-            @jet layer(x, ps, st) target_modules = (Lux, LuxCore, LuxLib)
+            @jet layer(x, ps, st)
             __f = x -> sum(first(layer(x, ps, st)))
             @eval @test_gradients $__f $x gpu_testing=$ongpu atol=1.0f-3 rtol=1.0f-3
         end

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -87,7 +87,7 @@
                     atol = 5 * eps(Float32)
                 ))
 
-            @jet layer(x, ps, st)
+            @jet layer(x, ps, st) target_modules = (Lux, LuxCore, LuxLib)
             __f = x -> sum(first(layer(x, ps, st)))
             @eval @test_gradients $__f $x gpu_testing=$ongpu atol=1.0f-3 rtol=1.0f-3
         end

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -81,7 +81,7 @@
             shifted_val = layer(x .+ Δx, ps, st)[1] |> Array
 
             @test all(val[1:4, :, :, :] .== shifted_val[1:4, :, :, :]) &&
-                all(isapprox(
+                all(isapprox.(
                     val[5:8, :, :, :],
                     shifted_val[5:8, :, :, :];
                     atol=sqrt(eps(typeof(first(val))))

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -77,13 +77,13 @@
             x = randn(rng, 6, 4, 3, 2) |> aType
             Δx = [0.0, 12.0, -2π/5, 0.0, 0.0, 0.0] |> aType
 
-            @test all(
-                    layer(x, ps, st)[1][1:4, :, :, :] .==
-                    layer(x .+ Δx, ps, st)[1][1:4, :, :, :]
-                    ) &&
+            val = layer(x, ps, st)[1] |> Array
+            shifted_val = layer(x .+ Δx, ps, st)[1] |> Array
+
+            @test all(val[1:4, :, :, :] .== shifted_val[1:4, :, :, :]) &&
                 all(isapprox(
-                    layer(x, ps, st)[1][5:8, :, :, :],
-                    layer(x .+ Δx, ps, st)[1][5:8, :, :, :];
+                    val[5:8, :, :, :],
+                    shifted_val[5:8, :, :, :];
                     atol=sqrt(eps(typeof(first(x))))
                 ))
 

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -84,7 +84,7 @@
                 all(isapprox.(
                     val[5:8, :, :, :],
                     shifted_val[5:8, :, :, :];
-                    atol=sqrt(eps(typeof(first(val))))
+                    atol = 5 * eps(Float32)
                 ))
 
             @jet layer(x, ps, st)


### PR DESCRIPTION
Sometimes when we're using physics-informed neural networks (PINNs), we want to solve a PDE on a periodic domain. Common practice is currently to include loss terms enforcing the periodic boundary conditions. The layer added in this PR would structurally enforce periodicity in certain input dimensions by replacing those dimensions $x$ with $\sin(2\pi x / period)$ and $\cos(2\pi x / period)$. This enforces periodicity in a smooth and exact manner at the cost of increasing the effective dimensionality of the input by the number of periodic dimensions. Hopefully, that isn't too penalizing thanks to the scaling of neural nets to higher dimensions.