### PR TITLE
Reduce max chunksize

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lux"
 uuid = "b2108857-7c20-44ae-9111-449ecde12c47"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.5.43"
+version = "0.5.44"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/LuxForwardDiffExt/batched_ad.jl
+++ b/ext/LuxForwardDiffExt/batched_ad.jl
@@ -43,7 +43,7 @@ function Lux.__batched_jacobian_impl(f::F, backend::AutoForwardDiff{CK}, x) wher
     __f = @closure x -> f(reshape(x, x_size))
     tag = backend.tag === nothing ? ForwardDiff.Tag(__f, eltype(x)) : backend.tag
     chunksize = (CK === nothing || CK ≤ 0) ?
-                ForwardDiff.Chunk{ForwardDiff.pickchunksize(prod(size(x)[1:(end - 1)]))}() :
+                ForwardDiff.Chunk{min(prod(size(x)[1:(end - 1)]), 8)}() :
                 ForwardDiff.Chunk{CK}()
     return __batched_forwarddiff_jacobian(
         __f, reshape(x, :, size(x, ndims(x))), typeof(tag), chunksize)

--- a/test/helpers/batched_ad_tests.jl
+++ b/test/helpers/batched_ad_tests.jl
@@ -33,6 +33,19 @@
 
             @test J2≈J3 atol=1.0e-5 rtol=1.0e-5
         end
+
+        @testset "Issue #636 Chunksize Specialization" begin
+            for N in (2, 4, 8, 11, 12, 50, 51)
+                model = @compact(; potential=Dense(N => N, gelu)) do x
+                    return batched_jacobian(potential, AutoForwardDiff(), x)
+                end
+
+                ps, st = Lux.setup(Random.default_rng(), model) |> dev
+
+                x = randn(Float32, N, 3) |> dev
+                @test_nowarn model(x, ps, st)
+            end
+        end
     end
 end
 


### PR DESCRIPTION
Fixes #636 

I thought the compiler specializes till ntuple size 12, but that doesn't seem to be the case. Capping chunksize at 8.