### PR TITLE
Quality of Life Improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lux"
 uuid = "b2108857-7c20-44ae-9111-449ecde12c47"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.5.51"
+version = "0.5.52"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/examples/Basics/main.jl
+++ b/examples/Basics/main.jl
@@ -310,9 +310,9 @@ function sse(model, ps, st, X, y)
     return sum(abs2, y_pred .- y), st_new
 end
 sse(weight, bias, X, y) = sum(abs2, weight * X .+ bias .- y)
-loss_function(ps, X, y) = mse(model, ps, st, X, y)
+loss_function(ps, X, y) = sse(model, ps, st, X, y)
 
-println("Loss Value with ground true parameters: ", mse(W, b, x_samples, y_samples))
+println("Loss Value with ground true parameters: ", sse(W, b, x_samples, y_samples))
 
 for i in 1:100
     ## In actual code, don't use globals. But here I will simply for the sake of

--- a/examples/Basics/main.jl
+++ b/examples/Basics/main.jl
@@ -305,11 +305,11 @@ opt = Optimisers.Descent(0.01f0)
 opt_state = Optimisers.setup(opt, ps)
 
 # Define the loss function
-function mse(model, ps, st, X, y)
+function sse(model, ps, st, X, y)
     y_pred, st_new = model(X, ps, st)
     return sum(abs2, y_pred .- y), st_new
 end
-mse(weight, bias, X, y) = sum(abs2, weight * X .+ bias .- y)
+sse(weight, bias, X, y) = sum(abs2, weight * X .+ bias .- y)
 loss_function(ps, X, y) = mse(model, ps, st, X, y)
 
 println("Loss Value with ground true parameters: ", mse(W, b, x_samples, y_samples))

--- a/ext/LuxOptimisersExt.jl
+++ b/ext/LuxOptimisersExt.jl
@@ -49,6 +49,35 @@ function Lux.Experimental.apply_gradients!(ts::Lux.Experimental.TrainState, grad
         ts.states, ts.optimizer_state, ts.step + 1)
 end
 
+# Simple extension to the `adjust!` API
+function Optimisers.adjust!(ts::Lux.Experimental.TrainState, eta::Real)
+    st_opt = ts.optimizer_state
+    Optimisers.adjust!(st_opt, eta)
+    return Lux.Experimental.TrainState(ts.cache, ts.objective_function, ts.model,
+        ts.parameters, ts.states, st_opt, ts.step)
+end
+
+function Optimisers.adjust!(ts::Lux.Experimental.TrainState; kwargs...)
+    st_opt = ts.optimizer_state
+    Optimisers.adjust!(st_opt; kwargs...)
+    return Lux.Experimental.TrainState(ts.cache, ts.objective_function, ts.model,
+        ts.parameters, ts.states, st_opt, ts.step)
+end
+
+function Optimisers.adjust(ts::Lux.Experimental.TrainState, eta::Real)
+    st_opt = ts.optimizer_state
+    st_opt = Optimisers.adjust(st_opt, eta)
+    return Lux.Experimental.TrainState(ts.cache, ts.objective_function, ts.model,
+        ts.parameters, ts.states, st_opt, ts.step)
+end
+
+function Optimisers.adjust(ts::Lux.Experimental.TrainState; kwargs...)
+    st_opt = ts.optimizer_state
+    st_opt = Optimisers.adjust(st_opt; kwargs...)
+    return Lux.Experimental.TrainState(ts.cache, ts.objective_function, ts.model,
+        ts.parameters, ts.states, st_opt, ts.step)
+end
+
 # DistributedUtils
 @concrete struct DistributedOptimizer{B <: AbstractLuxDistributedBackend} <: AbstractRule
     backend::B

--- a/src/Lux.jl
+++ b/src/Lux.jl
@@ -25,7 +25,7 @@ using PrecompileTools: @recompile_invalidations
                     initialparameters, initialstates, parameterlength, statelength,
                     inputsize, outputsize, update_state, trainmode, testmode, setup, apply,
                     display_name, replicate
-    using LuxDeviceUtils: get_device
+    using LuxDeviceUtils: AbstractLuxDeviceAdaptor, get_device
 
     # @compact specific
     using MacroTools: MacroTools, block, combinedef, splitdef

--- a/src/Lux.jl
+++ b/src/Lux.jl
@@ -25,7 +25,7 @@ using PrecompileTools: @recompile_invalidations
                     initialparameters, initialstates, parameterlength, statelength,
                     inputsize, outputsize, update_state, trainmode, testmode, setup, apply,
                     display_name, replicate
-    using LuxDeviceUtils: AbstractLuxDeviceAdaptor, get_device
+    using LuxDeviceUtils: get_device
 
     # @compact specific
     using MacroTools: MacroTools, block, combinedef, splitdef

--- a/src/helpers/stateful.jl
+++ b/src/helpers/stateful.jl
@@ -52,6 +52,25 @@ mutable struct StatefulLuxLayer{ST, M <: AbstractExplicitLayer, psType, stType}
     end
 end
 
+function Base.show(io::IO, s::StatefulLuxLayer{ST}) where {ST}
+    if get(io, :typeinfo, nothing) === nothing  # e.g. top level in REPL
+        print(io, "StatefulLuxLayer{$ST}(\n")
+        _big_show(io, s.model, 4)
+    elseif !get(io, :compact, false)  # e.g. printed inside a Vector, but not a Matrix
+        print(io, "StatefulLuxLayer{$ST}(")
+        _layer_show(io, s.model)
+    else
+        print(io, "StatefulLuxLayer{$ST}(")
+        show(io, s.model)
+    end
+    print(io, ")")
+end
+
+function Functors.functor(::Type{<:StatefulLuxLayer{FT}}, x) where {FT}
+    return ((; x.model, x.ps, x.st, x.st_any),
+        nt -> StatefulLuxLayer{FT}(nt.model, nt.ps, nt.st, nt.st_any))
+end
+
 @inline LuxCore.parameterlength(m::StatefulLuxLayer) = LuxCore.parameterlength(m.model)
 @inline LuxCore.statelength(m::StatefulLuxLayer) = LuxCore.statelength(m.model)
 @inline LuxCore.apply(m::StatefulLuxLayer, x, p) = m(x, p)
@@ -77,19 +96,26 @@ function StatefulLuxLayer{false}(model::AbstractExplicitLayer, ps, st::NamedTupl
     return StatefulLuxLayer{false}(model, ps, nothing, st)
 end
 
-function (s::StatefulLuxLayer{true})(x, p=s.ps)
-    y, st = apply(s.model, x, p, s.st)
-    CRC.@ignore_derivatives begin
-        s.st = st
-    end
-    return y
-end
+@inline __get_state(s::StatefulLuxLayer{true}) = s.st
+@inline __get_state(s::StatefulLuxLayer{false}) = s.st_any
 
-function (s::StatefulLuxLayer{false})(x, p=s.ps)
-    y, st = apply(s.model, x, p, s.st_any)
-    CRC.@ignore_derivatives begin
-        s.st_any = st
-    end
+@inline function __set_state!(
+        s::StatefulLuxLayer{true, M, psType, stType}, st::stType) where {M, psType, stType}
+    s.st = st
+end
+function __set_state!(::StatefulLuxLayer{true, M, psType, stType},
+        ::stType2) where {M, psType, stType, stType2}
+    throw(ArgumentError("Output state from the model has type `$(stType2)`, but expected \
+        `$(stType)`. Construct the Stateful layer as `StatefulLuxLayer{false}` instead \
+        of `StatefulLuxLayer{true}`."))
+end
+@inline __set_state!(s::StatefulLuxLayer{false}, st) = (s.st_any = st)
+
+CRC.@non_differentiable __set_state!(::Any...)
+
+function (s::StatefulLuxLayer)(x, p=s.ps)
+    y, st = apply(s.model, x, p, __get_state(s))
+    __set_state!(s, st.layer_1)
     return y
 end
 

--- a/src/helpers/stateful.jl
+++ b/src/helpers/stateful.jl
@@ -53,17 +53,7 @@ mutable struct StatefulLuxLayer{ST, M <: AbstractExplicitLayer, psType, stType}
 end
 
 function Base.show(io::IO, s::StatefulLuxLayer{ST}) where {ST}
-    if get(io, :typeinfo, nothing) === nothing  # e.g. top level in REPL
-        print(io, "StatefulLuxLayer{$ST}(\n")
-        _big_show(io, s.model, 4)
-    elseif !get(io, :compact, false)  # e.g. printed inside a Vector, but not a Matrix
-        print(io, "StatefulLuxLayer{$ST}(")
-        _layer_show(io, s.model)
-    else
-        print(io, "StatefulLuxLayer{$ST}(")
-        show(io, s.model)
-    end
-    print(io, ")")
+    _print_wrapper_model(io, "StatefulLuxLayer{$ST}", s.model)
 end
 
 function Functors.functor(::Type{<:StatefulLuxLayer{FT}}, x) where {FT}
@@ -115,7 +105,7 @@ CRC.@non_differentiable __set_state!(::Any...)
 
 function (s::StatefulLuxLayer)(x, p=s.ps)
     y, st = apply(s.model, x, p, __get_state(s))
-    __set_state!(s, st.layer_1)
+    __set_state!(s, st)
     return y
 end
 

--- a/src/layers/containers.jl
+++ b/src/layers/containers.jl
@@ -147,7 +147,7 @@ end
     getinput(i) = T <: Tuple ? :(x[$i]) : :x
     calls = []
     append!(calls,
-        [:(($(y_symbols[i]), $(st_symbols[i])) = Lux.apply(
+        [:(($(y_symbols[i]), $(st_symbols[i])) = LuxCore.apply(
              layers.$(names[i]), $(getinput(i)), ps.$(names[i]), st.$(names[i])))
          for i in 1:N])
     push!(calls, :(st = NamedTuple{$names}((($(Tuple(st_symbols)...),)))))

--- a/src/layers/display.jl
+++ b/src/layers/display.jl
@@ -119,3 +119,17 @@ end
 function underscorise(n::Integer)
     return join(reverse(join.(reverse.(Iterators.partition(digits(n), 3)))), '_')
 end
+
+function _print_wrapper_model(io::IO, desc::String, model::AbstractExplicitLayer)
+    if get(io, :typeinfo, nothing) === nothing  # e.g. top level in REPL
+        print(io, desc, "(\n")
+        _big_show(io, model, 4)
+    elseif !get(io, :compact, false)  # e.g. printed inside a Vector, but not a Matrix
+        print(io, desc, "(")
+        _layer_show(io, model)
+    else
+        print(io, desc, "(")
+        show(io, model)
+    end
+    print(io, ")")
+end

--- a/src/transform/simplechains.jl
+++ b/src/transform/simplechains.jl
@@ -38,7 +38,18 @@ julia> adaptor = ToSimpleChainsAdaptor((static(28), static(28), static(1)))
 ToSimpleChainsAdaptor{Tuple{Static.StaticInt{28}, Static.StaticInt{28}, Static.StaticInt{1}}}((static(28), static(28), static(1)), false)
 
 julia> simple_chains_model = adapt(adaptor, lux_model) # or adaptor(lux_model)
-SimpleChainsLayer()  # 47_154 parameters
+SimpleChainsLayer{false}(
+    Chain(
+        layer_1 = Conv((5, 5), 1 => 6, relu),  # 156 parameters
+        layer_2 = MaxPool((2, 2)),
+        layer_3 = Conv((5, 5), 6 => 16, relu),  # 2_416 parameters
+        layer_4 = MaxPool((2, 2)),
+        layer_5 = FlattenLayer(),
+        layer_6 = Dense(256 => 128, relu),  # 32_896 parameters
+        layer_7 = Dense(128 => 84, relu),  # 10_836 parameters
+        layer_8 = Dense(84 => 10),      # 850 parameters
+    ),
+)  # 47_154 parameters
 
 julia> ps, st = Lux.setup(Random.default_rng(), simple_chains_model);
 
@@ -72,7 +83,7 @@ function Adapt.adapt(to::ToSimpleChainsAdaptor, L::AbstractExplicitLayer)
         error("`ToSimpleChainsAdaptor` requires `SimpleChains.jl` to be loaded.")
     end
     sc_layer = __fix_input_dims_simplechain(__to_simplechains_adaptor(L), to.input_dims)
-    return SimpleChainsLayer{to.convert_to_array}(sc_layer)
+    return SimpleChainsLayer{to.convert_to_array}(sc_layer, L)
 end
 
 function __to_simplechains_adaptor end

--- a/test/contrib/training_tests.jl
+++ b/test/contrib/training_tests.jl
@@ -91,6 +91,19 @@ end
                 tstate = Lux.Experimental.apply_gradients!(tstate, grads)
             end
 
+            # Test the adjust API
+            tstate = Optimisers.adjust(tstate, 0.1f0)
+            @test tstate.optimizer_state.layer_1.weight.rule.eta ≈ 0.1f0
+
+            tstate = Optimisers.adjust(tstate; eta=0.5f0)
+            @test tstate.optimizer_state.layer_1.weight.rule.eta ≈ 0.5f0
+
+            Optimisers.adjust!(tstate, 0.01f0)
+            @test tstate.optimizer_state.layer_1.weight.rule.eta ≈ 0.01f0
+
+            Optimisers.adjust!(tstate; eta=0.11f0)
+            @test tstate.optimizer_state.layer_1.weight.rule.eta ≈ 0.11f0
+
             final_loss = first(mse(model, tstate.parameters, tstate.states, dataset_[1]))
 
             @test final_loss * 100 < initial_loss

--- a/test/helpers/stateful_tests.jl
+++ b/test/helpers/stateful_tests.jl
@@ -3,7 +3,7 @@
 
     struct NotFixedStateModel <: Lux.AbstractExplicitLayer end
 
-    (m::NotFixedStateModel)(x, ps, st) = (x, (; s = 1))
+    (m::NotFixedStateModel)(x, ps, st) = (x, (; s=1))
 
     model = NotFixedStateModel()
     ps, st = Lux.setup(rng, model)

--- a/test/helpers/stateful_tests.jl
+++ b/test/helpers/stateful_tests.jl
@@ -1,0 +1,20 @@
+@testitem "Simple Stateful Tests" setup=[SharedTestSetup] tags=[:helpers] begin
+    rng = get_stable_rng(12345)
+
+    struct NotFixedStateModel <: Lux.AbstractExplicitLayer end
+
+    (m::NotFixedStateModel)(x, ps, st) = (x, (; s = 1))
+
+    model = NotFixedStateModel()
+    ps, st = Lux.setup(rng, model)
+
+    @test st isa NamedTuple{()}
+
+    smodel = StatefulLuxLayer{false}(model, ps, st)
+    __display(smodel)
+    @test_nowarn smodel(1)
+
+    smodel = StatefulLuxLayer{true}(model, ps, st)
+    __display(smodel)
+    @test_throws ArgumentError smodel(1)
+end


### PR DESCRIPTION
1. Fixes #664 
2. Takes the improvements from https://github.com/LuxDL/Lux.jl/pull/661
3. `Optimisers.adjust!` and `Optimisers.adjust` can be directly applied to `TrainState`.
4. `StatefulLuxLayer` has pretty printing
5. `StatefulLuxLayer` is compatible with Adapt, so `gpu_device()` / `cpu_device()` can be directly applied to them.
6. SimpleChains model printing now displays the internal model