### PR TITLE
Add CartesianEmbedding layer

### DIFF
--- a/docs/src/api/Lux/layers.md
+++ b/docs/src/api/Lux/layers.md
@@ -98,5 +98,6 @@ Upsample
 ## SciML Layers
 
 ```@docs
+CartesianEmbedding
 PeriodicEmbedding
 ```

--- a/src/Lux.jl
+++ b/src/Lux.jl
@@ -88,7 +88,7 @@ include("deprecated.jl")
 export cpu, gpu  # deprecated
 
 export Chain, Parallel, SkipConnection, PairwiseFusion, BranchLayer, Maxout, RepeatedLayer
-export Bilinear, Dense, Embedding, Scale, PeriodicEmbedding
+export Bilinear, Dense, Embedding, Scale, CartesianEmbedding, PeriodicEmbedding
 export Conv, ConvTranspose, CrossCor, MaxPool, MeanPool, GlobalMaxPool, GlobalMeanPool,
        AdaptiveMaxPool, AdaptiveMeanPool, Upsample, PixelShuffle
 export AlphaDropout, Dropout, VariationalHiddenDropout

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -70,6 +70,47 @@
             @eval @test_gradients $__f $x gpu_testing=$ongpu atol=1.0f-3 rtol=1.0f-3
         end
 
+        @testset "CartesianEmbedding" begin
+            vocab_size, embed_size = (5, 2), 4
+            layer = CartesianEmbedding(vocab_size => embed_size)
+            __display(layer)
+            ps, st = Lux.setup(rng, layer) .|> device
+
+            @test size(ps.weight) == (embed_size, vocab_size...)
+
+            @test LuxCore.outputsize(layer) == (4,)
+
+            x = (rand(1:vocab_size[1], 1)[1], rand(1:vocab_size[2], 1)[1])
+            y, st_ = layer(x, ps, st)
+            @test size(layer(x, ps, st)[1]) == (embed_size,)
+            @test y == ps.weight[:, x...]
+
+            @jet layer(x, ps, st)
+
+            x = (rand(1:vocab_size[1], 3), rand(1:vocab_size[2], 3)) .|> aType
+            y, st_ = layer(x, ps, st)
+            @test y isa aType{Float32}
+            @test y == ps.weight[:, CartesianIndex.(x...)]
+
+            @jet layer(x, ps, st)
+
+            x = (rand(1:vocab_size[1], 3, 4), rand(1:vocab_size[2], 3, 4)) .|> aType
+            y, st_ = layer(x, ps, st)
+            @test y isa aType{Float32, 3}
+            @test size(y) == (embed_size, 3, 4)
+
+            @jet layer(x, ps, st)
+
+            x = (rand(1:vocab_size[1], 3), rand(1:vocab_size[2], 4)) .|> aType
+            @test_throws DimensionMismatch layer(x, ps, st)
+
+            x = (rand(1:vocab_size[1], 3, 4), rand(1:vocab_size[2], 4, 5)) .|> aType
+            @test_throws DimensionMismatch layer(x, ps, st)
+
+            x = ()
+            @test_throws ArgumentError layer(x, ps, st)
+        end
+
         @testset "PeriodicEmbedding" begin
             layer = PeriodicEmbedding([2, 3], [4.0, π / 5])
             __display(layer)


### PR DESCRIPTION
Lux currently offers an [Embedding](https://lux.csail.mit.edu/v0.5.51/api/Lux/layers#Lux.Embedding) layer that [calls](https://github.com/LuxDL/Lux.jl/blob/v0.5.51/src/layers/basic.jl#L500) the [NNlib.gather](https://fluxml.ai/Flux.jl/v0.14.15/models/nnlib/#NNlib.gather) method with [linear indices as arguments](https://github.com/FluxML/NNlib.jl/blob/v0.9.17/src/gather.jl#L41).

This pull request adds a CartesianEmbedding layer that allows using the other NNlib.gather method with [Cartesian indices as arguments](https://github.com/FluxML/NNlib.jl/blob/v0.9.17/src/gather.jl#L72-L73). This eliminates the need to convert manually from linear to Cartesian indices to use NNlib.gather, which significantly improves performance and reduce the number of allocations, especially on the GPU.

**Example**

```julia
# Julia v1.10.3
using Pkg
Pkg.activate(; temp=true)
Pkg.add(; url="https://github.com/ldeso/Lux.jl", rev="add-cartesianembedding-layer")
using Lux, Random

weights = [10.0 20.0 30.0
           40.0 50.0 60.0]
i = [1, 1, 1, 2, 2]
j = [1, 2, 3, 1, 2]
idx = (i, j)

rng = Random.default_rng()
model = CartesianEmbedding(size(weights) => 1; init_weight=Returns(weights))

ps, st = Lux.setup(rng, model)

model(idx, ps, st)[1]  # returns [10.0, 20.0, 30.0, 40.0, 50.0]
```

Closes #670