### PR TITLE
Update docstring dropout 

### DIFF
--- a/src/layers/dropout.jl
+++ b/src/layers/dropout.jl
@@ -71,7 +71,7 @@ Dropout layer.
 ## Keyword Arguments
 
   - To apply dropout along certain dimension(s), specify the `dims` keyword. e.g.
-    `Dropout(p; dims = 3)` will randomly zero out entire channels on WHCN input
+    `Dropout(p; dims = (3,4))` will randomly zero out entire channels on WHCN input
     (also called 2D dropout).
 
 ## Inputs


### PR DESCRIPTION
The current docstring for dropout suggests that `Dropout(p, dims = 3)` is equivalent to Dropout 2D for a WHCN input. 
I think  `Dropout(p, dims = (3, 4))` is the actual Dropout2D.
The current version dropout the same channel for each sample (fourth dimension), while the proposed version drops independently channels for each sample of the batch.