### PR TITLE
test: remove `@test_nowarn` testing

### DIFF
--- a/test/contrib/debug_tests.jl
+++ b/test/contrib/debug_tests.jl
@@ -34,7 +34,7 @@
 
         ps, st = Lux.setup(rng, model_fixed) |> device
 
-        @test_nowarn model_fixed(x, ps, st)
+        @test model_fixed(x, ps, st) isa Any
 
         model_fixed_debug = Lux.Experimental.@debug_mode model_fixed
 

--- a/test/distributed/data_distributedtest.jl
+++ b/test/distributed/data_distributedtest.jl
@@ -25,7 +25,7 @@ backend = DistributedUtils.get_distributed_backend(backend_type)
 data = randn(rng, Float32, 10)
 dcontainer = DistributedUtils.DistributedDataContainer(backend, data)
 
-@test_nowarn dcontainer[1]
+@test dcontainer[1] isa Any
 
 rank = DistributedUtils.local_rank(backend)
 tworkers = DistributedUtils.total_workers(backend)

--- a/test/distributed/optimizer_distributedtest.jl
+++ b/test/distributed/optimizer_distributedtest.jl
@@ -25,7 +25,7 @@ st_dopt = Optimisers.setup(dopt, ps)
 @test st_dopt.a.state == st_opt.a.state
 @test st_dopt.b.state == st_opt.b.state
 
-@test_nowarn DistributedUtils.synchronize!!(backend, st_dopt)
+@test DistributedUtils.synchronize!!(backend, st_dopt) isa Any
 
 gs = (a=ones(4), b=ones(4)) |> dev
 
@@ -35,4 +35,4 @@ _, ps_opt = Optimisers.update(st_opt, ps, gs)
 @test ps_dopt.a≈ps_opt.a atol=1.0e-5 rtol=1.0e-5
 @test ps_dopt.b≈ps_opt.b atol=1.0e-5 rtol=1.0e-5
 
-@test_nowarn Optimisers.adjust(st_dopt, 0.1f0)
+@test Optimisers.adjust(st_dopt, 0.1f0) isa Any

--- a/test/distributed/synchronize_distributedtest.jl
+++ b/test/distributed/synchronize_distributedtest.jl
@@ -60,7 +60,7 @@ st_opt = DistributedUtils.synchronize!!(backend, st_opt; root)
 opt = Descent(0.001f0)
 st_opt = Optimisers.setup(opt, gs)
 
-@test_nowarn DistributedUtils.synchronize!!(backend, st_opt; root)
+@test DistributedUtils.synchronize!!(backend, st_opt; root) isa Any
 
 ## ComponentArrays
 gs = (

--- a/test/helpers/batched_ad_tests.jl
+++ b/test/helpers/batched_ad_tests.jl
@@ -42,7 +42,7 @@
                 ps, st = Lux.setup(Random.default_rng(), model) |> dev
 
                 x = randn(Float32, N, 3) |> dev
-                @test_nowarn model(x, ps, st)
+                @test first(model(x, ps, st)) isa AbstractArray{<:Any, 3}
             end
         end
 
@@ -103,7 +103,7 @@ end
                 return sum(abs2, J)
             end
 
-            @test_nowarn loss_function_batched(model, X, ps, st)
+            @test loss_function_batched(model, X, ps, st) isa Number
             @test loss_function_batched(model, X, ps, st) ≈
                   loss_function_simple(model, X, ps, st)
 

--- a/test/helpers/compact_tests.jl
+++ b/test/helpers/compact_tests.jl
@@ -274,7 +274,7 @@
         end
 
         @testset "Keyword Arguments with Anonymous Function" begin
-            model = @test_nowarn @compact(x->@return(x+a+b); a=1, b=2)
+            model = @compact(x->@return(x+a+b); a=1, b=2)
             ps, st = Lux.setup(rng, model) |> device
             @test first(model(3, ps, st)) == 1 + 2 + 3
             expected_string = """@compact(

--- a/test/helpers/nestedad_tests.jl
+++ b/test/helpers/nestedad_tests.jl
@@ -238,7 +238,6 @@ end
                 return sum(J * vec(jvp_input))
             end
 
-            @test_nowarn loss_function_vjp(model, X, ps, st, vjp_input)
             @test loss_function_vjp(model, X, ps, st, vjp_input) isa Number
             @test loss_function_vjp(model, X, ps, st, vjp_input) ≈
                   loss_function_vjp_jacobian(model, X, ps, st, vjp_input)
@@ -250,7 +249,6 @@ end
             @test ∂x≈∂x_vjp rtol=1e-3 atol=1e-3
             @test check_approx(∂ps, ∂ps_vjp; rtol=1e-3, atol=1e-3)
 
-            @test_nowarn loss_function_jvp(model, X, ps, st, jvp_input)
             @test loss_function_jvp(model, X, ps, st, jvp_input) isa Number
             @test loss_function_jvp(model, X, ps, st, jvp_input) ≈
                   loss_function_jvp_jacobian(model, X, ps, st, jvp_input)
@@ -301,7 +299,7 @@ end
     nt = (functor=functorABC(rand(rng, 3), rand(rng, 3)), tup=(rand(rng, 3), rand(rng, 3)))
     u = (functor=functorABC(rand(rng, 3), rand(rng, 3)), tup=(rand(rng, 3), rand(rng, 3)))
 
-    @test_nowarn jacobian_vector_product(ftest, AutoForwardDiff(), nt, u)
+    @test jacobian_vector_product(ftest, AutoForwardDiff(), nt, u) isa Any
 end
 
 @testitem "Nested AD: Issue #743 (eval + gradient)" setup=[SharedTestSetup] tags=[:autodiff] begin

--- a/test/helpers/stateful_tests.jl
+++ b/test/helpers/stateful_tests.jl
@@ -16,7 +16,7 @@
 
     smodel = StatefulLuxLayer{false}(model, ps, st)
     display(smodel)
-    @test_nowarn smodel(1)
+    @test smodel(1) isa Any
 
     smodel = StatefulLuxLayer{true}(model, ps, st)
     display(smodel)

--- a/test/layers/conv_tests.jl
+++ b/test/layers/conv_tests.jl
@@ -314,19 +314,19 @@ end
 
     @testset "$mode" for (mode, aType, dev, ongpu) in MODES
         @testset "Construction" begin
-            @test_nowarn Upsample(:nearest; scale=2)
-            @test_nowarn Upsample(:nearest; size=(64, 64))
-            @test_nowarn Upsample(:bilinear; scale=2)
-            @test_nowarn Upsample(:bilinear; size=(64, 64))
-            @test_nowarn Upsample(:trilinear; scale=2)
-            @test_nowarn Upsample(:trilinear; size=(64, 64))
+            @test Upsample(:nearest; scale=2) isa Any
+            @test Upsample(:nearest; size=(64, 64)) isa Any
+            @test Upsample(:bilinear; scale=2) isa Any
+            @test Upsample(:bilinear; size=(64, 64)) isa Any
+            @test Upsample(:trilinear; scale=2) isa Any
+            @test Upsample(:trilinear; size=(64, 64)) isa Any
 
             @test_throws ArgumentError Upsample(:linear; scale=2)
             @test_throws ArgumentError Upsample(:nearest; scale=2, size=(64, 64))
             @test_throws ArgumentError Upsample(:nearest)
 
-            @test_nowarn Upsample(2)
-            @test_nowarn Upsample(2, :nearest)
+            @test Upsample(2) isa Any
+            @test Upsample(2, :nearest) isa Any
         end
 
         @testset "Size Correctness" begin
@@ -625,7 +625,7 @@ end
             x = randn(Float32, 28, 28, 42, 3) |> aType
             ps, st = Lux.setup(rng, layer) |> dev
 
-            @test_nowarn layer(x, ps, st)
+            @test layer(x, ps, st) isa Any
 
             x = randn(Float32, 28, 28, 46, 3) |> aType
 

--- a/test/layers/normalize_tests.jl
+++ b/test/layers/normalize_tests.jl
@@ -297,15 +297,15 @@ end
             @test_throws ArgumentError Lux.setup(rng, wn)
 
             wn = WeightNorm(c, (:weight,))
-            @test_nowarn Lux.setup(rng, wn)
+            @test Lux.setup(rng, wn) isa Any
 
             c = Conv((3, 3), 3 => 3; init_bias=Lux.ones32)
 
             wn = WeightNorm(c, (:weight, :bias))
-            @test_nowarn Lux.setup(rng, wn)
+            @test Lux.setup(rng, wn) isa Any
 
             wn = WeightNorm(c, (:weight,))
-            @test_nowarn Lux.setup(rng, wn)
+            @test Lux.setup(rng, wn) isa Any
         end
     end
 end

--- a/test/utils_tests.jl
+++ b/test/utils_tests.jl
@@ -95,15 +95,15 @@ end
         @test -p_flat == getdata(-ps_c)
         @test zero(p_flat) == getdata(zero(ps_c))
 
-        @test_nowarn similar(ps_c, 10)
-        @test_nowarn similar(ps_c)
+        @test similar(ps_c, 10) isa Any
+        @test similar(ps_c) isa Any
 
         ps_c_f, ps_c_re = Functors.functor(ps_c)
         @test ps_c_f == ps
         @test ps_c_re(ps_c_f) == ps_c
 
         # Empty ComponentArray test
-        @test_nowarn display(ComponentArray(NamedTuple()))
+        @test display(ComponentArray(NamedTuple())) isa Any
         println()
 
         # Optimisers
@@ -111,8 +111,8 @@ end
         ps_c = ps_c |> device
         st_opt = Optimisers.setup(opt, ps_c)
 
-        @test_nowarn Optimisers.update(st_opt, ps_c, ps_c)
-        @test_nowarn Optimisers.update!(st_opt, ps_c, ps_c)
+        @test Optimisers.update(st_opt, ps_c, ps_c) isa Any
+        @test Optimisers.update!(st_opt, ps_c, ps_c) isa Any
     end
 
     # Ref: https://github.com/LuxDL/Lux.jl/issues/243
@@ -120,7 +120,7 @@ end
     ps, st = Lux.setup(rng, nn)
 
     l2reg(p) = sum(abs2, ComponentArray(p))
-    @test_nowarn Zygote.gradient(l2reg, ps)
+    @test length(Zygote.gradient(l2reg, ps)) == 1
 end
 
 @testitem "_init_hidden_state" setup=[SharedTestSetup] tags=[:recurrent_layers] begin
@@ -277,7 +277,7 @@ end
     c = Parallel(+; chain=Chain(; dense_1=Dense(2 => 3), dense_2=Dense(3 => 5)),
         dense_3=Dense(5 => 1))
 
-    @test_nowarn fmap(println, c)
+    @test fmap(println, c) isa Any
 
     l = Dense(2 => 2)
     new_model = fmap(x -> l, c)


### PR DESCRIPTION
These are very fragile and prevents us from throwing deprecation warnings without breaking downstream testing