### PR TITLE
fix: don't reuse pullback for safety

### DIFF
--- a/ext/LuxZygoteExt/LuxZygoteExt.jl
+++ b/ext/LuxZygoteExt/LuxZygoteExt.jl
@@ -5,6 +5,7 @@ using ADTypes: AutoZygote
 using ChainRulesCore: ChainRulesCore
 using ForwardDiff: ForwardDiff
 using Lux: Lux
+using LuxDeviceUtils: get_device_type, LuxCPUDevice
 using Setfield: @set!
 using Zygote: Zygote
 


### PR DESCRIPTION
- avoids reusing the pullback function. This will lead to some slowdowns but guarantees correctness
- enables threading for CPU