### PR TITLE
docs: fix typo in "JVP & VJP Wrappers"

### DIFF
--- a/docs/src/api/Lux/autodiff.md
+++ b/docs/src/api/Lux/autodiff.md
@@ -6,7 +6,7 @@
 Pages = ["autodiff.md"]
 ```
 
-## JVP & JVP Wrappers
+## JVP & VJP Wrappers
 
 ```@docs
 jacobian_vector_product


### PR DESCRIPTION
Replace "JVP & JVP Wrappers" with "JVP & VJP Wrappers" in https://lux.csail.mit.edu/stable/api/Lux/autodiff