### PR TITLE
Fix images.jl link

### DIFF
--- a/docs/src/ecosystem.md
+++ b/docs/src/ecosystem.md
@@ -183,7 +183,7 @@ const dataload = [
     name: 'Images.jl',
     desc: 'An image library for Julia',
     links: [
-      { icon: 'github', link: 'ttps://github.com/JuliaImages/Images.jl' }
+      { icon: 'github', link: 'https://github.com/JuliaImages/Images.jl' }
     ]
   },
   {


### PR DESCRIPTION
Fix images.jl link in [ecosystem](https://lux.csail.mit.edu/stable/ecosystem) page