### PR TITLE
Add TrainState docstring with Optimisers API

### DIFF
--- a/docs/src/api/Lux/utilities.md
+++ b/docs/src/api/Lux/utilities.md
@@ -13,6 +13,7 @@ basic building blocks which can be seamlessly composed to create complex trainin
 
 ```@docs
 Training.TrainState
+Training.TrainState(::AbstractLuxLayer, ::Any, ::Any, ::Optimisers.AbstractRule)
 Training.compute_gradients
 Training.apply_gradients
 Training.apply_gradients!


### PR DESCRIPTION
The default TrainState docstring suggests using the version with the Optimisers API, but it doesn't appear in the doc website. Add the docstring manually to the website by adding the method to a @docs block.