### PR TITLE
test: allow the latest AMDGPU to be installed

### DIFF
--- a/lib/LuxLib/test/runtests.jl
+++ b/lib/LuxLib/test/runtests.jl
@@ -20,7 +20,7 @@ if (BACKEND_GROUP == "all" || BACKEND_GROUP == "cuda")
     end
 end
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "amdgpu") &&
-    push!(EXTRA_PKGS, PackageSpec(; name="AMDGPU", version=v"1.0.4"))
+    push!(EXTRA_PKGS, PackageSpec(; name="AMDGPU"))
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "oneapi") &&
     push!(EXTRA_PKGS, PackageSpec(; name="oneAPI"))
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "metal") &&

--- a/lib/MLDataDevices/test/runtests.jl
+++ b/lib/MLDataDevices/test/runtests.jl
@@ -15,7 +15,7 @@ if (BACKEND_GROUP == "all" || BACKEND_GROUP == "cuda")
     end
 end
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "amdgpu") &&
-    push!(EXTRA_PKGS, PackageSpec(; name="AMDGPU", version=v"1.0.4"))
+    push!(EXTRA_PKGS, PackageSpec(; name="AMDGPU"))
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "oneapi") &&
     push!(EXTRA_PKGS, PackageSpec(; name="oneAPI"))
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "metal") &&

--- a/lib/WeightInitializers/test/runtests.jl
+++ b/lib/WeightInitializers/test/runtests.jl
@@ -10,7 +10,7 @@ const EXTRA_PKGS = PackageSpec[]
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "cuda") &&
     push!(EXTRA_PKGS, PackageSpec("CUDA"))
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "amdgpu") &&
-    push!(EXTRA_PKGS, PackageSpec(; name="AMDGPU", version=v"1.0.4"))
+    push!(EXTRA_PKGS, PackageSpec(; name="AMDGPU"))
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "metal") &&
     push!(EXTRA_PKGS, PackageSpec("Metal"))
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "oneapi") &&

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ if (BACKEND_GROUP == "all" || BACKEND_GROUP == "cuda")
     end
 end
 (BACKEND_GROUP == "all" || BACKEND_GROUP == "amdgpu") &&
-    push!(EXTRA_PKGS, Pkg.PackageSpec(; name="AMDGPU", version=v"1.0.4"))
+    push!(EXTRA_PKGS, Pkg.PackageSpec(; name="AMDGPU"))
 
 if !isempty(EXTRA_PKGS) || !isempty(EXTRA_DEV_PKGS)
     @info "Installing Extra Packages for testing" EXTRA_PKGS EXTRA_DEV_PKGS


### PR DESCRIPTION
with 1.11.2 this should have been fixed.

fixes #1095 