### PR TITLE
don't declare implicitly exported functions public

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,12 +1,12 @@
 # Recursive Operations --> Functors.fmap
 @deprecate recursive_add!!(x, y) Functors.fmap(
     Utils.add!!, x, y; exclude=MLDataDevices.isleaf
-) false
-@deprecate recursive_make_zero(x) Functors.fmap(Utils.zero, x; exclude=MLDataDevices.isleaf) false
+)
+@deprecate recursive_make_zero(x) Functors.fmap(Utils.zero, x; exclude=MLDataDevices.isleaf)
 @deprecate recursive_make_zero!!(x) Functors.fmap(
     Utils.zero!!, x; exclude=MLDataDevices.isleaf
-) false
+)
 @deprecate recursive_copyto!(x, y) Functors.fmap(
     copyto!, x, y; exclude=MLDataDevices.isleaf
-) false
-@deprecate recursive_map(f, args...) Functors.fmap(f, args...; exclude=MLDataDevices.isleaf) false
+)
+@deprecate recursive_map(f, args...) Functors.fmap(f, args...; exclude=MLDataDevices.isleaf)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,12 +1,12 @@
 # Recursive Operations --> Functors.fmap
 @deprecate recursive_add!!(x, y) Functors.fmap(
     Utils.add!!, x, y; exclude=MLDataDevices.isleaf
-)
-@deprecate recursive_make_zero(x) Functors.fmap(Utils.zero, x; exclude=MLDataDevices.isleaf)
+) false
+@deprecate recursive_make_zero(x) Functors.fmap(Utils.zero, x; exclude=MLDataDevices.isleaf) false
 @deprecate recursive_make_zero!!(x) Functors.fmap(
     Utils.zero!!, x; exclude=MLDataDevices.isleaf
-)
+) false
 @deprecate recursive_copyto!(x, y) Functors.fmap(
     copyto!, x, y; exclude=MLDataDevices.isleaf
-)
-@deprecate recursive_map(f, args...) Functors.fmap(f, args...; exclude=MLDataDevices.isleaf)
+) false
+@deprecate recursive_map(f, args...) Functors.fmap(f, args...; exclude=MLDataDevices.isleaf) false

--- a/src/helpers/recursive_ops.jl
+++ b/src/helpers/recursive_ops.jl
@@ -110,3 +110,5 @@ For the following types it directly defines recursion rules:
     correctness of this implementation for specific usecases.
 """
 function recursive_map end
+
+@compat(public, (recursive_eltype,))

--- a/src/helpers/recursive_ops.jl
+++ b/src/helpers/recursive_ops.jl
@@ -110,7 +110,3 @@ For the following types it directly defines recursion rules:
     correctness of this implementation for specific usecases.
 """
 function recursive_map end
-
-@compat(public,
-    (recursive_add!!, recursive_copyto!, recursive_eltype,
-        recursive_make_zero, recursive_map, recursive_make_zero!!))


### PR DESCRIPTION
`@deprecate` by default exports the passed functions, <s>which I assume was not intended here</s>. This actually causes precompilation errors on 1.12 since these functions are also declared public, so remove the declaration as public