### PR TITLE
Add way to silence gpu warning

### DIFF
--- a/lib/MLDataDevices/src/internal.jl
+++ b/lib/MLDataDevices/src/internal.jl
@@ -93,9 +93,9 @@ function get_gpu_device(; force::Bool)
     end
 
     force && throw(DeviceSelectionException("GPU"))
-    @warn """No functional GPU backend found! Defaulting to CPU.
+    Base.get_bool_env("MLDATADEVICES_SILENCE_WARN_NO_GPU", true) && @warn """No functional GPU backend found! Defaulting to CPU.
 
-    1. If no GPU is available, nothing needs to be done.
+    1. If no GPU is available, nothing needs to be done. Set `MLDATADEVICES_SILENCE_WARN_NO_GPU=1` to silence this warning.
     2. If GPU is available, load the corresponding trigger package.
         a. `CUDA.jl` and `cuDNN.jl` (or just `LuxCUDA.jl`) for  NVIDIA CUDA Support.
         b. `AMDGPU.jl` for AMD GPU ROCM Support.


### PR DESCRIPTION
I see this so much because a package I depend on still wraps stuff in `gpu` because it used to not be something that warranted a warning.