### PR TITLE
Update OptimizationIntegration/main.jl comment to match link title

### DIFF
--- a/examples/OptimizationIntegration/main.jl
+++ b/examples/OptimizationIntegration/main.jl
@@ -1,4 +1,4 @@
-# # [Training Lux Models using Optimization.jl](@id Optimization-Lux-Tutorial)
+# # [Fitting with Optimization.jl](@id Optimization-Lux-Tutorial)
 
 # Lux's native [Training.TrainState](@ref) is a great API for gradient-based learning of
 # neural networks, however, it is geared towards using `Optimisers.jl` as the backend.


### PR DESCRIPTION
Changed Training Lux Models using Optimization.jl to Fitting with Optimization.jl to match the link name "Fitting with Optimization.jl" in the sidebar.