### PR TITLE
show debug instead of warning if cant cuBLAS mult

### DIFF
--- a/lib/LuxLib/ext/LuxLibCUDAExt/cublaslt.jl
+++ b/lib/LuxLib/ext/LuxLibCUDAExt/cublaslt.jl
@@ -306,7 +306,7 @@ function LuxLib.Impl.cublasLt_fused_dense!(
         )
         @warn warn_msg maxlog = 1
     else
-        @warn "cuBLASLt not available. Falling back to generic implementation." maxlog = 1
+        @debug "cuBLASLt not available. Falling back to generic implementation." maxlog = 1
     end
     # Generic fallback
     if y === nothing


### PR DESCRIPTION
For some special array types, promotion to a `CuArray` can be more expensive than the cost of using a generic matmul method (e.g. `OneHotArray`), so this warning was inappropriate.