### PR TITLE
allow SelectDim to take arbitrary views

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -202,7 +202,7 @@ SelectDim(dim::Integer, index::AbstractVector) = SelectDim(static(dim), index)
 function (s::SelectDim{D,<:StaticInt})(x, _, st::NamedTuple) where {D}
     return selectdim(x, known(s.dim), known(s.index)), st
 end
-(s::SelectDim)(x, _, st::NamedTuple) = selectdim(x, known(s.dim), s.index)
+(s::SelectDim)(x, _, st::NamedTuple) = selectdim(x, known(s.dim), s.index), st
 
 function Base.show(io::IO, s::SelectDim)
     return print(io, "SelectDim(dim = ", s.dim, ", index = ", s.index, ")")

--- a/test/layers/basic_tests.jl
+++ b/test/layers/basic_tests.jl
@@ -75,6 +75,13 @@
             @test size(layer(x, ps, st)[1]) == (6, 4, 2)
             @jet layer(x, ps, st)
             @test_gradients(sumabs2first, layer, x, ps, st; atol=1.0f-3, rtol=1.0f-3)
+
+            layer = SelectDim(2, 1:2)
+            display(layer)
+            ps, st = dev(Lux.setup(rng, layer))
+            x = aType(randn(rng, 6, 4, 3, 2))
+            @test size(layer(x, ps, st)[1]) == (6, 2, 3, 2)
+            @test_gradients(sumabs2first, layer, x, ps, st; atol=1.0f-3, rtol=1.0f-3)
         end
 
         @testset "WrappedFunction" begin


### PR DESCRIPTION
This allows `SelectDim` to take any view.  This functionality is already supported by `Base.selectdim` so it only requires loosening type restrictions.  I allowed it to use arbitrary `AbstractVector`s but obviously using completely arbitrary non-contiguous views is inadvisable in most cases (it's still not entirely clear to me how good an idea it is to use `view` in deep learning on GPU's anyway).