### PR TITLE
Fix up minor docs/docstrings formatting

### DIFF
--- a/docs/src/manual/dispatch_custom_input.md
+++ b/docs/src/manual/dispatch_custom_input.md
@@ -59,34 +59,34 @@ end
 
 * Create a Custom Layer storing the time.
 
-```@example dispatch
-struct ArrayAndTime{A <: AbstractArray, T <: Real}
-    array::A
-    time::T
-end
-```
+  ```@example dispatch
+  struct ArrayAndTime{A <: AbstractArray, T <: Real}
+      array::A
+      time::T
+  end
+  ```
 
 * Define the dispatch on `Lux.apply(::AbstractLuxLayer, x::ArrayAndTime, ps, st::NamedTuple)`.
 
-```@example dispatch
-function Lux.apply(layer::Lux.AbstractLuxLayer, x::ArrayAndTime, ps, st::NamedTuple)
-    y, st = layer(x.array, ps, st)
-    return ArrayAndTime(y, x.time), st
-end
+  ```@example dispatch
+  function Lux.apply(layer::Lux.AbstractLuxLayer, x::ArrayAndTime, ps, st::NamedTuple)
+      y, st = layer(x.array, ps, st)
+      return ArrayAndTime(y, x.time), st
+  end
 
-function Lux.apply(layer::TDChain, x::ArrayAndTime, ps, st::NamedTuple)
-    y, st = layer((x.array, x.time), ps, st)
-    return ArrayAndTime(y, x.time), st
-end
-```
+  function Lux.apply(layer::TDChain, x::ArrayAndTime, ps, st::NamedTuple)
+      y, st = layer((x.array, x.time), ps, st)
+      return ArrayAndTime(y, x.time), st
+  end
+  ```
 
 * Run the model.
 
-```@example dispatch
-xt = ArrayAndTime(x, 10.0f0)
+  ```@example dispatch
+  xt = ArrayAndTime(x, 10.0f0)
 
-model(xt, ps, st)[1]
-```
+  model(xt, ps, st)[1]
+  ```
 
 ### Using the Same Input for Non-TD Models
 

--- a/lib/LuxLib/src/api/dense.jl
+++ b/lib/LuxLib/src/api/dense.jl
@@ -25,7 +25,7 @@ multiple operations.
     medium sized matrices. This is overridden if special BLAS implementations are loaded
     (currently `MKL`, `AppleAccelerate`, and `BLISBLAS`).
 
-!!! tip "Load `Octavian.jl`
+!!! tip "Load `Octavian.jl`"
 
     Loading `Octavian.jl` enables a polyalgorithm that uses different backends based on the
     input sizes.

--- a/src/layers/attention.jl
+++ b/src/layers/attention.jl
@@ -28,9 +28,11 @@ The multi-head dot-product attention layer used in Transformer architectures
 
 ## Forward Pass Signature(s)
 
-    (m::MultiHeadAttention)(qkv, ps, st::NamedTuple)
-    (m::MultiHeadAttention)((q, kv), ps, st::NamedTuple)
-    (m::MultiHeadAttention)((q, k, v, [mask = nothing]), ps, st::NamedTuple)
+```julia
+(m::MultiHeadAttention)(qkv, ps, st::NamedTuple)
+(m::MultiHeadAttention)((q, kv), ps, st::NamedTuple)
+(m::MultiHeadAttention)((q, k, v, [mask = nothing]), ps, st::NamedTuple)
+```
 
 ## Inputs
 

--- a/src/layers/attention.jl
+++ b/src/layers/attention.jl
@@ -10,12 +10,15 @@ The multi-head dot-product attention layer used in Transformer architectures
 ## Arguments
 
   - `dims`: The embedding dimensions of inputs, intermediate tensors and outputs.
-            In the most general case, it is given as
-            a) `(q_in_dim, k_in_dim, v_in_dim) => (qk_dim, v_dim) => out_dim`.
-            Can take also simpler forms as
-            b) `dims::Int`;
-            c) `in_dim::Int => (qk_dim, v_dim) => out_dim`;
-            d) `in_dim::Int => qkv_dim => out_dim`.
+    In the most general case, it is given as
+
+    + a) `(q_in_dim, k_in_dim, v_in_dim) => (qk_dim, v_dim) => out_dim`.
+
+    Can take also simpler forms as
+
+    + b) `dims::Int`;
+    + c) `in_dim::Int => (qk_dim, v_dim) => out_dim`;
+    + d) `in_dim::Int => qkv_dim => out_dim`.
 
 ## Keyword Arguments
 

--- a/src/layers/containers.jl
+++ b/src/layers/containers.jl
@@ -623,21 +623,21 @@ computation, however, semantically this is same as:
 
   - `input_injection = Val(false)`
 
-```julia
-res = x
-for i in 1:repeats
-    res, st = model(res, ps, st)
-end
-```
+    ```julia
+    res = x
+    for i in 1:repeats
+        res, st = model(res, ps, st)
+    end
+    ```
 
   - `input_injection = Val(true)`
 
-```julia
-res = x
-for i in 1:repeats
-    res, st = model((res, x), ps, st)
-end
-```
+    ```julia
+    res = x
+    for i in 1:repeats
+        res, st = model((res, x), ps, st)
+    end
+    ```
 
 It is expected that `repeats` will be a reasonable number below `20`, beyond that compile
 times for gradients might be unreasonably high.

--- a/src/layers/embedding.jl
+++ b/src/layers/embedding.jl
@@ -32,7 +32,7 @@ This layer is often used to store word embeddings and retrieve them using indice
     input, an N + 1 dimensional output is returned.
   - Empty `NamedTuple()`
 
-!!! warning "Gradients with Tracker.jl
+!!! warning "Gradients with Tracker.jl"
 
     Tracker.jl produces incorrect gradients for this layer if indices in the input are
     repeated. Don't use this layer with Tracker.jl if you need to compute gradients.

--- a/src/layers/embedding.jl
+++ b/src/layers/embedding.jl
@@ -175,10 +175,10 @@ dimensions for efficiency.
 
 ## Input
 
-  - 4D AbstractArray s.t.
+  - 4D AbstractArray such that
 
-      + size(x, 1) == dim
-      + size(x, 3) ≤ max_sequence_length
+      + `size(x, 1) == dim`
+      + `size(x, 3) ≤ max_sequence_length`
 
 ## Returns
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -107,12 +107,14 @@ automatically operate over a sequence of inputs.
     to handle sequentially composed RNN Cells. In Lux, one can simple stack multiple
     `Recurrence` blocks in a `Chain` to achieve the same.
 
-        Chain(
-            Recurrence(RNNCell(inputsize => latentsize); return_sequence=true),
-            Recurrence(RNNCell(latentsize => latentsize); return_sequence=true),
-            :
-            x -> stack(x; dims=2)
-        )
+    ```julia
+    Chain(
+        Recurrence(RNNCell(inputsize => latentsize); return_sequence=true),
+        Recurrence(RNNCell(latentsize => latentsize); return_sequence=true),
+        :
+        x -> stack(x; dims=2)
+    )
+    ```
 
     For some discussion on this topic, see https://github.com/LuxDL/Lux.jl/issues/472.
 """

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -375,10 +375,10 @@ Long Short-Term (LSTM) Cell
 \begin{align}
   i &= \sigma(W_{ii} \times x + W_{hi} \times h_{prev} + b_{i})\\
   f &= \sigma(W_{if} \times x + W_{hf} \times h_{prev} + b_{f})\\
-  g &= tanh(W_{ig} \times x + W_{hg} \times h_{prev} + b_{g})\\
+  g &= \tanh(W_{ig} \times x + W_{hg} \times h_{prev} + b_{g})\\
   o &= \sigma(W_{io} \times x + W_{ho} \times h_{prev} + b_{o})\\
   c_{new} &= f \cdot c_{prev} + i \cdot g\\
-  h_{new} &= o \cdot tanh(c_{new})
+  h_{new} &= o \cdot \tanh(c_{new})
 \end{align}
 ```
 


### PR DESCRIPTION
- Fix up markdown lists by moving code blocks into list elements (for dispatch_custom_input.md, `MultiHeadAttention`, `RepeatedLayer`)
- Add end quotes to fix admonition blocks (for `fused_dense_bias_activation`, `Embedding`)
- Add syntax highlighting/monospace formatting to blocks (for `MultiHeadAttention`, `Embedding`, `Recurrence`)
- Use `\tanh` in TeX block (for `LSTMCell`)