### PR TITLE
fix: State returned by MultiHeadAttention is incompatible with the initialized state

### DIFF
--- a/src/layers/attention.jl
+++ b/src/layers/attention.jl
@@ -185,8 +185,8 @@ function apply_multiheadattention(mha::MultiHeadAttention, ps, st, q, k, v, mask
             q_proj=q_st,
             k_proj=k_st,
             v_proj=v_st,
-            out_proj=out_st,
             attention_dropout=dropout.st,
+            out_proj=out_st,
         ),
     )
 end


### PR DESCRIPTION
fixes #1383 

The order of elements in the returned state tuple has been modified to match the original Struct definition.

