### PR TITLE
Change doc title in docs/src/introduction/index.md

### DIFF
--- a/docs/src/introduction/index.md
+++ b/docs/src/introduction/index.md
@@ -1,4 +1,4 @@
-# [Getting Started](@id getting-started)
+# [Introduction](@id getting-started)
 
 ## Installation
 

--- a/docs/src/introduction/resources.md
+++ b/docs/src/introduction/resources.md
@@ -1,8 +1,8 @@
 # Resources to Get Started
 
-* Go through the [Quickstart Example](@ref getting-started).
+* Go through the [Quickstart Example](@ref Quickstart).
 * Read the introductory tutorials on
-  [Julia](https://jump.dev/JuMP.jl/stable/tutorials/getting_started/getting_started_with_julia/#Getting-started-with-Julia)
+  [Julia](https://jump.dev/JuMP.jl/stable/tutorials/getting_started/getting_started_with_julia)
   and Lux.
 * Go through the examples sorted based on their complexity in the documentation.
 


### PR DESCRIPTION
Having the title called "Getting Started" messes up the nav bar, and the "Next page" navigation button at the bottom of the page. Also update the link in docs/src/introduction/resources.md