### PR TITLE
Fix typos and fix up minor docs formatting

### DIFF
--- a/docs/src/manual/debugging.md
+++ b/docs/src/manual/debugging.md
@@ -42,7 +42,7 @@ catch e
 end
 ```
 
-Ofcourse, this error will come with a detailed stacktrace, but it is still not very useful.
+Of course, this error will come with a detailed stacktrace, but it is still not very useful.
 Now let's try using the debug mode model:
 
 ```@example manual_debugging

--- a/examples/Basics/main.jl
+++ b/examples/Basics/main.jl
@@ -120,7 +120,7 @@ W * x
 
 # ## (Im)mutability
 
-# Lux as you might have read is Immutable by convention
+# Lux as you might have read is "Immutable by convention,"
 # which means that the core library is built without any form of mutation and all functions
 # are pure. However, we don't enforce it in any form. We do **strongly recommend** that
 # users extending this framework for their respective applications don't mutate their

--- a/examples/Basics/main.jl
+++ b/examples/Basics/main.jl
@@ -222,7 +222,7 @@ v = ones(Float32, 5)
 #     here come with additional goodies like
 #     [fast second-order derivatives](@ref nested_autodiff).
 
-# Compute the jvp. `AutoForwardDiff` specifies that we want to use `ForwardDiff.jl` for the
+# Compute the JVP. `AutoForwardDiff` specifies that we want to use `ForwardDiff.jl` for the
 # Jacobian-Vector Product
 
 jvp = jacobian_vector_product(f, AutoForwardDiff(), x, v)

--- a/examples/Basics/main.jl
+++ b/examples/Basics/main.jl
@@ -230,7 +230,7 @@ println("JVP: ", jvp)
 
 # ### Vector-Jacobian Product
 
-# Using the same function and inputs, let us compute the VJP.
+# Using the same function and inputs, let us compute the Vector-Jacobian Product (VJP).
 
 vjp = vector_jacobian_product(f, AutoZygote(), x, v)
 println("VJP: ", vjp)
@@ -239,7 +239,7 @@ println("VJP: ", vjp)
 
 # Finally, now let us consider a linear regression problem. From a set of data-points
 # $\{ (x_i, y_i), i \in \{ 1, \dots, k \}, x_i \in \mathbb{R}^n, y_i \in \mathbb{R}^m \}$,
-# we try to find a set of parameters $W$ and $b$, s.t. $f_{W,b}(x) = Wx + b$, which
+# we try to find a set of parameters $W$ and $b$, such that $f_{W,b}(x) = Wx + b$, which
 # minimizes the mean squared error:
 
 # $$L(W, b) \longrightarrow \sum_{i = 1}^{k} \frac{1}{2} \| y_i - f_{W,b}(x_i) \|_2^2$$

--- a/examples/ConvolutionalVAE/main.jl
+++ b/examples/ConvolutionalVAE/main.jl
@@ -67,7 +67,7 @@ function cvae_encoder(
         ## Generate a tensor of random values from a normal distribution
         ϵ = randn_like(Lux.replicate(rng), σ)
 
-        ## Reparameterization trick to brackpropagate through sampling
+        ## Reparameterization trick to backpropagate through sampling
         z = ϵ .* σ .+ μ
 
         @return z, μ, logσ²

--- a/examples/GCN_Cora/main.jl
+++ b/examples/GCN_Cora/main.jl
@@ -1,6 +1,7 @@
 # # [Graph Convolutional Networks on Cora](@id GCN-Tutorial-Cora)
 
-# This example is based on [GCN MLX tutorial](https://github.com/ml-explore/mlx-examples/blob/main/gcn/). While we are doing this manually, we recommend directly using
+# This example is based on [GCN MLX tutorial](https://github.com/ml-explore/mlx-examples/blob/main/gcn/).
+# While we are doing this manually, we recommend directly using
 # [GNNLux.jl](https://juliagraphs.org/GraphNeuralNetworks.jl/docs/GNNLux.jl/stable/).
 
 using Lux,

--- a/examples/GravitationalWaveForm/main.jl
+++ b/examples/GravitationalWaveForm/main.jl
@@ -241,8 +241,8 @@ const nn = Chain(
 )
 ps, st = Lux.setup(Random.default_rng(), nn)
 
-# Similar to most DL frameworks, Lux defaults to using `Float32`, however, in this case we
-# need Float64
+# Similar to most deep learning frameworks, Lux defaults to using `Float32`.
+# However, in this case we need Float64
 
 const params = ComponentArray(f64(ps))
 

--- a/examples/GravitationalWaveForm/main.jl
+++ b/examples/GravitationalWaveForm/main.jl
@@ -25,7 +25,7 @@ using CairoMakie
 #     This section can be skipped. It defines functions to simulate the model, however,
 #     from a scientific machine learning perspective, isn't super relevant.
 
-# We need a very crude 2-body path. Assume the 1-body motion is a newtonian 2-body position
+# We need a very crude 2-body path. Assume the 1-body motion is a Newtonian 2-body position
 # vector $r = r_1 - r_2$ and use Newtonian formulas to get $r_1$, $r_2$ (e.g. Theoretical
 # Mechanics of Particles and Continua 4.3)
 
@@ -142,7 +142,7 @@ function h_22_quadrupole_two_body(dt, orbit1, mass1, orbit2, mass2)
 end
 
 function h_22_strain_two_body(dt::T, orbit1, mass1, orbit2, mass2) where {T}
-    ## compute (2,2) mode strain from orbits of BH 1 of mass1 and BH2 of mass 2
+    ## compute (2,2) mode strain from orbits of BH1 of mass1 and BH2 of mass 2
 
     @assert abs(mass1 + mass2 - 1.0) < 1.0e-12 "Masses do not sum to unity"
 
@@ -176,7 +176,7 @@ nothing #hide
 # ## Simulating the True Model
 
 # `RelativisticOrbitModel` defines system of odes which describes motion of point like
-# particle in schwarzschild background, uses
+# particle in Schwarzschild background, uses
 
 # $$u[1] = \chi$$
 # $$u[2] = \phi$$
@@ -222,13 +222,13 @@ begin
     fig
 end
 
-# ## Defiing a Neural Network Model
+# ## Defining a Neural Network Model
 
 # Next, we define the neural network model that takes 1 input (time) and has two outputs.
 # We'll make a function `ODE_model` that takes the initial conditions, neural network
 # parameters and a time as inputs and returns the derivatives.
 
-# It is typically never recommended to use globals but incase you do use them, make sure
+# It is typically never recommended to use globals but in case you do use them, make sure
 # to mark them as `const`.
 
 # We will deviate from the standard Neural Network initialization and use

--- a/examples/HyperNet/main.jl
+++ b/examples/HyperNet/main.jl
@@ -127,7 +127,7 @@ function train()
         @compile model((data_idx, x), ps, Lux.testmode(st))
     end
 
-    ### Lets train the model
+    ### Let's train the model
     nepochs = 50
     for epoch in 1:nepochs, data_idx in 1:2
         train_dataloader, test_dataloader = dev.(dataloaders[data_idx])

--- a/examples/NeuralODE/main.jl
+++ b/examples/NeuralODE/main.jl
@@ -186,7 +186,7 @@ nothing #hide
 train(NeuralODE)
 nothing #hide
 
-# We can also change the sensealg and train the model! `GaussAdjoint` allows you to use
+# We can also change the `sensealg` and train the model! `GaussAdjoint` allows you to use
 # any arbitrary parameter structure and not just a flat vector (`ComponentArray`).
 
 train(NeuralODE; sensealg=GaussAdjoint(; autojacvec=ZygoteVJP()), use_named_tuple=true)

--- a/examples/PINN2DPDE/main.jl
+++ b/examples/PINN2DPDE/main.jl
@@ -5,7 +5,7 @@
 # However, we will be using our custom loss function and use nested AD capabilities of
 # Lux.jl.
 
-# This is a demonstration of Lux.jl. For serious usecases of PINNs, please refer to
+# This is a demonstration of Lux.jl. For serious use cases of PINNs, please refer to
 # the package: [NeuralPDE.jl](https://github.com/SciML/NeuralPDE.jl).
 
 # ## Package Imports
@@ -33,7 +33,7 @@ nothing #hide
 
 # ## Define the Neural Networks
 
-# All the networks take 3 input variables and output a scalar value. Here, we will define a
+# All the networks take 3 input variables and output a scalar value. Here, we will define
 # a wrapper over the 3 networks, so that we can train them using
 # [`Training.TrainState`](@ref).
 

--- a/examples/PINN2DPDE/main.jl
+++ b/examples/PINN2DPDE/main.jl
@@ -83,7 +83,7 @@ function physics_informed_loss_function(model::StatefulLuxLayer, xyt::AbstractAr
 end
 nothing #hide
 
-# Additionally, we need to compute the loss wrt the boundary conditions.
+# Additionally, we need to compute the loss with respect to the boundary conditions.
 
 function mse_loss_function(
     model::StatefulLuxLayer, target::AbstractArray, xyt::AbstractArray

--- a/examples/SimpleRNN/main.jl
+++ b/examples/SimpleRNN/main.jl
@@ -27,12 +27,12 @@ function create_dataset(; dataset_size=1000, sequence_length=50)
     ## Get the labels
     labels = vcat(repeat([0.0f0], dataset_size ÷ 2), repeat([1.0f0], dataset_size ÷ 2))
     clockwise_spirals = [
-        reshape(d[1][:, 1:sequence_length], :, sequence_length, 1) for
-        d in data[1:(dataset_size ÷ 2)]
+        reshape(d[1][:, 1:sequence_length], :, sequence_length, 1)
+        for d in data[1:(dataset_size ÷ 2)]
     ]
     anticlockwise_spirals = [
-        reshape(d[1][:, (sequence_length + 1):end], :, sequence_length, 1) for
-        d in data[((dataset_size ÷ 2) + 1):end]
+        reshape(d[1][:, (sequence_length + 1):end], :, sequence_length, 1)
+        for d in data[((dataset_size ÷ 2) + 1):end]
     ]
     x_data = Float32.(cat(clockwise_spirals..., anticlockwise_spirals...; dims=3))
     return x_data, labels

--- a/examples/SimpleRNN/main.jl
+++ b/examples/SimpleRNN/main.jl
@@ -57,9 +57,9 @@ nothing #hide
 # ## Creating a Classifier
 
 # We will be extending the `Lux.AbstractLuxContainerLayer` type for our custom model
-# since it will contain a lstm block and a classifier head.
+# since it will contain a LSTM block and a classifier head.
 
-# We pass the fieldnames `lstm_cell` and `classifier` to the type to ensure that the
+# We pass the field names `lstm_cell` and `classifier` to the type to ensure that the
 # parameters and states are automatically populated and we don't have to define
 # `Lux.initialparameters` and `Lux.initialstates`.
 
@@ -130,7 +130,7 @@ nothing #hide
 
 # ## Defining Accuracy, Loss and Optimiser
 
-# Now let's define the binarycrossentropy loss. Typically it is recommended to use
+# Now let's define the binary cross-entropy loss. Typically it is recommended to use
 # `logitbinarycrossentropy` since it is more numerically stable, but for the sake of
 # simplicity we will use `binarycrossentropy`.
 const lossfn = BinaryCrossEntropyLoss()

--- a/examples/SimpleRNN/main.jl
+++ b/examples/SimpleRNN/main.jl
@@ -9,7 +9,7 @@
 
 # ## Package Imports
 
-# Note: If you wish to use AutoZygote() for automatic differentiation,
+# Note: If you wish to use `AutoZygote()` for automatic differentiation,
 # add Zygote to your project dependencies and include `using Zygote`.
 
 using ADTypes, Lux, JLD2, MLUtils, Optimisers, Printf, Reactant, Random

--- a/src/helpers/losses.jl
+++ b/src/helpers/losses.jl
@@ -213,7 +213,7 @@ Returns the binary cross entropy loss computed as:
 
 - If `logits` is `true` or `Val(true)`:
 
-  $$\text{agg}\left((1 - \tilde{y}) * \hat{y} - log\sigma(\hat{y})\right)$$
+  $$\text{agg}\left((1 - \tilde{y}) * \hat{y} - \log\sigma(\hat{y})\right)$$
 
 The value of $\tilde{y}$ is computed using label smoothing. If `label_smoothing` is
 `nothing`, then no label smoothing is applied. If `label_smoothing` is a real number
@@ -422,7 +422,7 @@ end
 Return the Dice Coefficient loss [milletari2016v](@cite) which is used in segmentation
 tasks. The dice coefficient is similar to the F1_score. Loss calculated as:
 
-$$agg\left(1 - \frac{2 \sum y \hat{y} + \alpha}{\sum y^2 + \sum \hat{y}^2 + \alpha}\right)$$
+$$\text{agg}\left(1 - \frac{2 \sum y \hat{y} + \alpha}{\sum y^2 + \sum \hat{y}^2 + \alpha}\right)$$
 
 where $\alpha$ is the smoothing factor (`smooth`).
 

--- a/src/layers/embedding.jl
+++ b/src/layers/embedding.jl
@@ -175,14 +175,14 @@ dimensions for efficiency.
 
 ## Input
 
-  - 4D AbstractArray such that
+  - 4D `AbstractArray` such that
 
       + `size(x, 1) == dim`
       + `size(x, 3) ≤ max_sequence_length`
 
 ## Returns
 
-  - 4D AbstractArray of the same size as the input.
+  - 4D `AbstractArray` of the same size as the input.
 
 ## States
 


### PR DESCRIPTION
- Fix typos and/or spelling
- Fix up markdown and TeX formatting
- Expand acronyms in some text locations to help readability