### PR TITLE
Use `write(filename, obj)` for file I/O in docs

### DIFF
--- a/docs/src/manual/exporting_to_jax.md
+++ b/docs/src/manual/exporting_to_jax.md
@@ -47,9 +47,7 @@ hlo_code = @code_hlo model(x, ps, st)
 Now we just save this into an `mlir` file.
 
 ```@example exporting_to_stablehlo
-open("exported_lux_model.mlir", "w") do io
-    write(io, string(hlo_code))
-end
+write("exported_lux_model.mlir", string(hlo_code))
 nothing # hide
 ```
 

--- a/docs/src/manual/visualize_lux_models.md
+++ b/docs/src/manual/visualize_lux_models.md
@@ -31,9 +31,7 @@ we can save the `mlir` file.
 ```@example visualize_lux_models
 hlo = @code_hlo model(x, ps, Lux.testmode(st))
 
-open("exported_lux_model.mlir", "w") do io
-    write(io, string(hlo))
-end
+write("exported_lux_model.mlir", string(hlo))
 nothing # hide
 ```
 
@@ -49,9 +47,7 @@ end
 
 hlo = @code_hlo ∇sumabs2_enzyme(model, x, ps, st)
 
-open("exported_lux_model_gradients.mlir", "w") do io
-    write(io, string(hlo))
-end
+write("exported_lux_model_gradients.mlir", string(hlo))
 nothing # hide
 ```
 


### PR DESCRIPTION
Avoids `open()`-ing a file directly, and simpler to parse