### PR TITLE
docs: Fix wrong function name

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -153,7 +153,7 @@ Standard convolutional layer.
         `size(output,d) == size(x,d) / stride` (possibly rounded) for each spatial
         dimension.
       + Periodic padding can achieved by pre-empting the layer with a
-        `WrappedFunction(x -> NNlib.circular_pad(x, N_pad; dims=pad_dims))`
+        `WrappedFunction(x -> NNlib.pad_circular(x, N_pad; dims=pad_dims))`
 
   - `groups`: Expected to be an `Int`. It specifies the number of groups to divide a
               convolution into (set `groups = in_chs` for Depthwise Convolutions). `in_chs`


### PR DESCRIPTION
This changes `circular_pad` to `pad_circular`.