### PR TITLE
fix: pin ForwardDiff and CUDA versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Lux"
 uuid = "b2108857-7c20-44ae-9111-449ecde12c47"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.21.1"
+version = "1.21.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -91,7 +91,7 @@ Enzyme = "0.13.74"
 EnzymeCore = "0.8.13"
 FastClosures = "0.3.2"
 Flux = "0.16.3"
-ForwardDiff = "0.10.36, 1"
+ForwardDiff = "0.10.36, =1"
 FunctionWrappers = "1.1.3"
 Functors = "0.5"
 GPUArraysCore = "0.2"

--- a/lib/LuxCUDA/Project.toml
+++ b/lib/LuxCUDA/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCUDA"
 uuid = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.3.5"
+version = "0.3.4"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -9,7 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
-CUDA = "5.8 - 5.8.1"
+CUDA = "5.8"
 Reexport = "1"
 cuDNN = "1.3"
 julia = "1.10"

--- a/lib/LuxCUDA/Project.toml
+++ b/lib/LuxCUDA/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCUDA"
 uuid = "d0bbae9a-e099-4d5b-a835-1c6931763bda"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -9,7 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
-CUDA = "5.8"
+CUDA = "5.8 - 5.8.1"
 Reexport = "1"
 cuDNN = "1.3"
 julia = "1.10"

--- a/test/distributed/Project.toml
+++ b/test/distributed/Project.toml
@@ -14,6 +14,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Lux = {path = "../.."}
 LuxCUDA = {path = "../../lib/LuxCUDA"}
 MLDataDevices = {path = "../../lib/MLDataDevices"}
+NCCL = { url = "https://github.com/LuxDL/NCCL.jl", rev = "cd85e9f7830be425b64d2eee407df7d61a6a9635" }
 
 [compat]
 ComponentArrays = "0.15.29"

--- a/test/distributed/common_distributedtest.jl
+++ b/test/distributed/common_distributedtest.jl
@@ -11,7 +11,7 @@ end
 
 const backend_type = input_args[2] == "nccl" ? NCCLBackend : MPIBackend
 
-if input_args[1] == "nccl"
+if input_args[2] == "nccl"
     using NCCL
 end
 

--- a/test/distributed/data_distributedtest.jl
+++ b/test/distributed/data_distributedtest.jl
@@ -17,7 +17,7 @@ end
 
 const backend_type = input_args[2] == "nccl" ? NCCLBackend : MPIBackend
 
-if input_args[1] == "nccl"
+if input_args[2] == "nccl"
     using NCCL
 end
 

--- a/test/distributed/optimizer_distributedtest.jl
+++ b/test/distributed/optimizer_distributedtest.jl
@@ -11,7 +11,7 @@ end
 
 const backend_type = input_args[2] == "nccl" ? NCCLBackend : MPIBackend
 
-if input_args[1] == "nccl"
+if input_args[2] == "nccl"
     using NCCL
 end
 

--- a/test/distributed/synchronize_distributedtest.jl
+++ b/test/distributed/synchronize_distributedtest.jl
@@ -11,7 +11,7 @@ end
 
 const backend_type = input_args[2] == "nccl" ? NCCLBackend : MPIBackend
 
-if input_args[1] == "nccl"
+if input_args[2] == "nccl"
     using NCCL
 end
 


### PR DESCRIPTION
I am going to pin these till upstream PRs get merged. Can't have CI red unnecessarily.

1. https://github.com/JuliaDiff/ForwardDiff.jl/pull/760
2. https://github.com/JuliaGPU/NCCL.jl/pull/63