### PR TITLE
Indent code blocks to make it part of ordered list

### DIFF
--- a/src/layers/containers.jl
+++ b/src/layers/containers.jl
@@ -389,21 +389,21 @@ Layer behaves differently based on input type:
  1. If the input `x` is a tuple of length `N + 1`, then the `layers` must be a tuple of
     length `N`. The computation is as follows
 
-```julia
-y = x[1]
-for i in 1:N
-    y = connection(x[i + 1], layers[i](y))
-end
-```
+    ```julia
+    y = x[1]
+    for i in 1:N
+        y = connection(x[i + 1], layers[i](y))
+    end
+    ```
 
  2. Any other kind of input
 
-```julia
-y = x
-for i in 1:N
-    y = connection(x, layers[i](y))
-end
-```
+    ```julia
+    y = x
+    for i in 1:N
+        y = connection(x, layers[i](y))
+    end
+    ```
 
 ## Returns
 


### PR DESCRIPTION
Note: the fix in this commit doesn't even work. The rendered list is still fragmented, with a single item list, then a code block, then another single item list, then another code block.

However, the second list does start at 2 as opposed to 1 in the current build. Unsure of the build intricacies involved here. But for most Markdown parsers, it should appear as one list.