### PR TITLE
Fixed legend labels for the curves in the PolynomialFitting documentation page

### DIFF
--- a/examples/PolynomialFitting/main.jl
+++ b/examples/PolynomialFitting/main.jl
@@ -48,7 +48,7 @@ begin
         color=:orange,
         strokecolor=:black,
         strokewidth=2,
-        label="Data Points",
+        label="Actual Data",
     )
 
     axislegend(ax)


### PR DESCRIPTION
Current visualisation [here](https://lux.csail.mit.edu/stable/tutorials/beginner/2_PolynomialFitting#Dataset) has the wrong labels (they should be switched).

PR simply switches the labels