### PR TITLE
Add continue-on-error + input toggles for telemetry and cache in CommonCI

### DIFF
--- a/.github/workflows/CommonCI.yml
+++ b/.github/workflows/CommonCI.yml
@@ -36,6 +36,16 @@ on:
         required: false
         type: string
         default: ""
+      enable_telemetry:
+        description: "Enable Workflow Telemetry collection"
+        required: false
+        type: boolean
+        default: true
+      enable_cache:
+        description: "Enable Julia package cache"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   test:
@@ -52,7 +62,9 @@ jobs:
         run: |
           mkdir -p ${{ env.TMPDIR }}
       - name: Collect Workflow Telemetry
+        if: ${{ inputs.enable_telemetry }}
         uses: catchpoint/workflow-telemetry-action@v2
+        continue-on-error: true
         with:
           comment_on_pr: false
           job_summary: true
@@ -60,6 +72,8 @@ jobs:
         with:
           version: ${{ inputs.julia_version }}
       - uses: julia-actions/cache@v3
+        if: ${{ inputs.enable_cache }}
+        continue-on-error: true
         with:
           cache-name: julia-cache;workflow=${{ inputs.julia_version }}-${{ inputs.os }}-${{ github.event_name }}-${{ inputs.project }}-${{ inputs.downgrade_testing }}-${{ inputs.local_dependencies }}-${{ inputs.local_test_dependencies }}-${{ inputs.test_args }}
 


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` on the `catchpoint/workflow-telemetry-action@v2` and `julia-actions/cache@v3` steps so infrastructure failures don't fail the job when tests pass.
- Add two new optional boolean inputs: `enable_telemetry` (default `true`) and `enable_cache` (default `true`), gating each step with `if: ${{ inputs.enable_* }}`. Downstream repos can set these to `false` to skip entirely.
- Fully backward-compatible — both inputs default to `true`, so existing callers don't change behavior.

## Why

Downstream consumers of `CommonCI.yml` on self-hosted runners are seeing spurious CI failures:

**Telemetry** (`catchpoint/workflow-telemetry-action@v2`):
```
##[error][Workflow Telemetry] AxiosError
##[error]AxiosError: Request failed with status code 413
```
The telemetry payload exceeds GitHub's API limit on repos with many parallel jobs. The action annotates `##[error]` during post-job cleanup, which marks the entire job as FAILURE even though all Julia tests passed.

**Cache** (`julia-actions/cache@v3`):
```
##[warning]uploadCacheArchiveSDK: internal error uploading cache archive:
Server failed to authenticate the request.
```
```
error: could not lock config file /home/chrisrackauckas/.gitconfig: File exists
##[error]Process completed with exit code 255.
```
On self-hosted runners sharing a Julia depot across concurrent jobs, cache operations hit file-locking and auth failures.

Both issues were consistently observed on [SciML/NonlinearSolve.jl#910](https://github.com/SciML/NonlinearSolve.jl/pull/910), where 5+ jobs reported FAILURE despite `Testing … tests passed` in the logs.

## Changes

| Step | Before | After |
|---|---|---|
| Telemetry | Always runs; failure = job failure | Gated by `enable_telemetry` (default true); `continue-on-error: true` |
| Cache | Always runs; failure = job failure | Gated by `enable_cache` (default true); `continue-on-error: true` |

The `continue-on-error` applies even when `enable_*` is true (the default), so existing Lux.jl CI gets the resilience benefit without changing any workflow files. Repos that want to opt out entirely can pass `enable_telemetry: false` / `enable_cache: false`.

## Test plan

- [ ] Lux.jl CI continues to work with defaults (no breaking change).
- [ ] Downstream SciML repos can pass `enable_telemetry: false` to eliminate the AxiosError noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)