### PR TITLE
Remove root "Getting started" page from nav menu

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -199,7 +199,6 @@ export default defineConfig({
         text: "Getting Started",
         collapsed: false,
         items: [
-          { text: "Introduction", link: "/introduction" },
           { text: "Overview", link: "/introduction/overview" },
           { text: "Resources", link: "/introduction/resources" },
           { text: "Updating to v1", link: "/introduction/updating_to_v1" },


### PR DESCRIPTION
index.md gets picked up by default from line 198, and including it makes a hyperlink loop at the end of the page. That is, instead of pointing to "Overview", it points back to "Introduction"