### PR TITLE
Revamp CUDA extension based on new cuDNN wrappers

### DIFF
--- a/lib/LuxLib/ext/cuDNNExt/batchnorm.jl
+++ b/lib/LuxLib/ext/cuDNNExt/batchnorm.jl
@@ -59,64 +59,16 @@ function batchnorm_cudnn!(
     rμ = safe_reshape(rμ′, dims...)
     rσ² = safe_reshape(rσ²′, dims...)
 
-    if rμ === nothing || rσ² === nothing
-        rμ !== rσ² && throw(ArgumentError("both or neither of rμ and rσ² must be nothing"))
-        rμ = CU_NULL
-        rσ² = CU_NULL
-    end
-
-    xd = cudnnTensorDescriptor(x)
-    yd = cudnnTensorDescriptor(y)
-    γβd = cudnnTensorDescriptor(
-        CUDNN_TENSOR_NCHW,
-        cudnnDataType(T),
-        Cint(length(dims)),
-        cuDNN.dim4(dims, Val(CUDNN_TENSOR_NCHW)),
-    )
+    (rμ === nothing) == (rσ² === nothing) ||
+        throw(ArgumentError("both or neither of rμ and rσ² must be nothing"))
 
     if unsafe_known(training)
-        μ = CUDA.zeros(T, dims)
-        σ⁻² = CUDA.ones(T, dims)
-
-        cudnnBatchNormalizationForwardTraining(
-            cuDNN.handle(),
-            CUDNN_BATCHNORM_SPATIAL,
-            cuDNN.scalingParameter(T, true),
-            cuDNN.scalingParameter(T, false),
-            xd,
-            x,
-            yd,
-            y,
-            γβd,
-            γ,
-            β,
-            m,
-            rμ,
-            rσ²,
-            ϵ,
-            μ,
-            σ⁻²,
+        return batchnorm_training!(
+            y, x, γ, β; running_mean=rμ, running_var=rσ², momentum=m, epsilon=ϵ
         )
-
-        return μ, σ⁻²
     else
-        cudnnBatchNormalizationForwardInference(
-            cuDNN.handle(),
-            CUDNN_BATCHNORM_SPATIAL,
-            cuDNN.scalingParameter(T, true),
-            cuDNN.scalingParameter(T, false),
-            xd,
-            x,
-            yd,
-            y,
-            γβd,
-            γ,
-            β,
-            rμ,
-            rσ²,
-            ϵ,
-        )
-
+        rμ === nothing && throw(ArgumentError("running statistics are required"))
+        batchnorm_inference!(y, x, γ, β, rμ, rσ²; epsilon=ϵ)
         return similar(x, zero.(dims)), similar(x, zero.(dims))
     end
 end
@@ -197,46 +149,16 @@ function ∇batchnorm_cudnn!(
     ∂γ = reshape(∂γ′, dims)
     γ = reshape(γ′, dims)
     ∂β = reshape(∂β′, dims)
-    rμ = safe_reshape(rμ′, dims...)
-    rσ² = safe_reshape(rσ²′, dims...)
 
-    if rμ === nothing && rσ² === nothing
-        rμ = CU_NULL
-        rσ² = CU_NULL
+    if xμ === nothing || xσ⁻² === nothing
+        xμ !== xσ⁻² &&
+            throw(ArgumentError("both or neither of xμ and xσ⁻² must be nothing"))
+        y = similar(x)
+        β = CUDA.zeros(T, dims)
+        xμ, xσ⁻² = batchnorm_training!(y, x, γ, β; epsilon=ϵ)
+        Utils.unsafe_free!(y)
+        Utils.unsafe_free!(β)
     end
 
-    xd = cudnnTensorDescriptor(x)
-    ∂yd = cudnnTensorDescriptor(∂y)
-    ∂xd = cudnnTensorDescriptor(∂x)
-    γd = cudnnTensorDescriptor(
-        CUDNN_TENSOR_NCHW,
-        cudnnDataType(T),
-        Cint(length(dims)),
-        cuDNN.dim4(dims, Val(CUDNN_TENSOR_NCHW)),
-    )
-
-    xμ = xμ === nothing ? CU_NULL : xμ
-    xσ⁻² = xσ⁻² === nothing ? CU_NULL : xσ⁻²
-
-    return cudnnBatchNormalizationBackward(
-        cuDNN.handle(),
-        CUDNN_BATCHNORM_SPATIAL,
-        cuDNN.scalingParameter(T, true),
-        cuDNN.scalingParameter(T, false),
-        cuDNN.scalingParameter(T, true),
-        cuDNN.scalingParameter(T, false),
-        xd,
-        x,
-        ∂yd,
-        ∂y,
-        ∂xd,
-        ∂x,
-        γd,
-        γ,
-        ∂γ,
-        ∂β,
-        ϵ,
-        xμ,
-        xσ⁻²,
-    )
+    return batchnorm_gradient!(∂x, ∂γ, ∂β, ∂y, x, γ, xμ, xσ⁻²; epsilon=ϵ)
 end

--- a/lib/LuxLib/ext/cuDNNExt/cuDNNExt.jl
+++ b/lib/LuxLib/ext/cuDNNExt/cuDNNExt.jl
@@ -2,17 +2,9 @@ module cuDNNExt
 
 using LuxLib: LuxLib, Optional, ∂∅, Impl
 using LuxLib.Utils: Utils, safe_reshape, safe_vec, unsafe_known, recursive_unthunk
-using CUDA: CUDA, CuArray, CuVector, CU_NULL, DenseCuArray, DenseCuVector
+using CUDA: CUDA, CuArray, CuVector, DenseCuArray, DenseCuVector
 using ChainRulesCore: ChainRulesCore
-using cuDNN:
-    cuDNN,
-    cudnnBatchNormalizationBackward,
-    cudnnBatchNormalizationForwardInference,
-    CUDNN_BATCHNORM_SPATIAL,
-    cudnnBatchNormalizationForwardTraining,
-    cudnnTensorDescriptor,
-    CUDNN_TENSOR_NCHW,
-    cudnnDataType
+using cuDNN: batchnorm_gradient!, batchnorm_inference!, batchnorm_training!
 using FastClosures: @closure
 using Static: StaticBool, False, True
 

--- a/lib/LuxLib/ext/cuDNNExt/cuDNNExt.jl
+++ b/lib/LuxLib/ext/cuDNNExt/cuDNNExt.jl
@@ -4,7 +4,9 @@ using LuxLib: LuxLib, Optional, ∂∅, Impl
 using LuxLib.Utils: Utils, safe_reshape, safe_vec, unsafe_known, recursive_unthunk
 using CUDA: CUDA, CuArray, CuVector, DenseCuArray, DenseCuVector
 using ChainRulesCore: ChainRulesCore
-using cuDNN: batchnorm_gradient!, batchnorm_inference!, batchnorm_training!
+using cuDNN: batchnorm_gradient!, batchnorm_gradient_supported,
+             batchnorm_inference!, batchnorm_inference_supported,
+             batchnorm_training!, batchnorm_training_supported
 using FastClosures: @closure
 using Static: StaticBool, False, True
 
@@ -12,7 +14,39 @@ const CRC = ChainRulesCore
 
 const cuDNNFloat = Union{Float32,Float64}
 
+const OptionalVector = Union{Nothing,AbstractVector}
+const BatchNormFallbackSignature =
+    Tuple{AbstractArray,OptionalVector,OptionalVector,OptionalVector,OptionalVector,
+          StaticBool,Any,Any,Any}
+
+function batchnorm_fallback(x, γ, β, rμ, rσ², training, σ, momentum, epsilon)
+    return invoke(Impl.batchnorm, BatchNormFallbackSignature, x, γ, β, rμ, rσ²,
+                  training, σ, momentum, epsilon)
+end
+
 include("batchnorm.jl")
+
+function batchnorm_cudnn_supported(γ, β, x, rμ, rσ², training, momentum, epsilon)
+    γ === nothing && return false
+    β === nothing && return false
+    if ndims(x) == 2
+        x = reshape(x, 1, 1, size(x, 1), size(x, 2))
+    end
+    dims = wsize(x, True())
+    γ = reshape(γ, dims)
+    β = reshape(β, dims)
+    rμ = safe_reshape(rμ, dims...)
+    rσ² = safe_reshape(rσ², dims...)
+    if unsafe_known(training)
+        batchnorm_training_supported(x, x, γ, β; running_mean=rμ,
+                                     running_var=rσ², momentum,
+                                     epsilon) || return false
+        return batchnorm_gradient_supported(x, γ, β, x, x, γ, γ, γ)
+    end
+    return batchnorm_inference_supported(x, x, γ, β, rμ, rσ²)
+end
+
+CRC.@non_differentiable batchnorm_cudnn_supported(::Any...)
 
 # api/batchnorm.jl
 function Impl.batchnorm(
@@ -27,8 +61,11 @@ function Impl.batchnorm(
     ϵ,
 ) where {T<:cuDNNFloat,F}
     rμₙ, rσ²ₙ = Impl.get_batchnorm_statistics(x, rμ, rσ², training)
-    y = Impl.batchnorm_cudnn(γ, β, x, rμₙ, rσ²ₙ, m, ϵ, training)[1]
-    return Impl.activation!!(σ, y), safe_vec(rμₙ), safe_vec(rσ²ₙ)
+    if batchnorm_cudnn_supported(γ, β, x, rμₙ, rσ²ₙ, training, m, ϵ)
+        y = Impl.batchnorm_cudnn(γ, β, x, rμₙ, rσ²ₙ, m, ϵ, training)[1]
+        return Impl.activation!!(σ, y), safe_vec(rμₙ), safe_vec(rσ²ₙ)
+    end
+    return batchnorm_fallback(x, γ, β, rμ, rσ², training, σ, m, ϵ)
 end
 
 function CRC.rrule(


### PR DESCRIPTION
https://github.com/JuliaGPU/CUDA.jl/pull/3191 modernizes CUDA.jl's cuDNN wrappers, deprecating the old imperative interface, instead adding one based on the new back-end API, with a higher-level interface on top. This PR reworks the extension here to be built on top of that new API.

Since I'm not actually a user of these interfaces, I'd appreciate if people would take a look and suggest any changes to make to the cuDNN wrappers to facilitate use here (I already had LLMs do as much as possible, taking into account what NNlib.jl and LuxLib.jl require, and how NVIDIA's high-level wrappers are implemented).