### PR TITLE
[LuxTestUtils] Move mooncake to an extension

### DIFF
--- a/lib/LuxTestUtils/Project.toml
+++ b/lib/LuxTestUtils/Project.toml
@@ -16,14 +16,19 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
-Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
+[weakdeps]
+Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+
 [sources]
 MLDataDevices = {path = "../MLDataDevices"}
+
+[extensions]
+MooncakeExt = "Mooncake"
 
 [compat]
 ADTypes = "1.10"

--- a/lib/LuxTestUtils/Project.toml
+++ b/lib/LuxTestUtils/Project.toml
@@ -1,6 +1,6 @@
 name = "LuxTestUtils"
 uuid = "ac9de150-d08f-4546-94fb-7472b5760531"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Avik Pal <avikpal@mit.edu>"]
 
 [deps]

--- a/lib/LuxTestUtils/ext/MooncakeExt.jl
+++ b/lib/LuxTestUtils/ext/MooncakeExt.jl
@@ -1,0 +1,44 @@
+module MooncakeExt
+
+using ADTypes: AutoMooncake
+using Mooncake: Mooncake
+using LuxTestUtils: LuxTestUtils
+
+function __init__()
+    @static if isempty(VERSION.prerelease)
+        try
+            # FIXME: Mooncake is currently wreaking havoc in the Lux repo test,
+            # dropping testing for now
+            # Mooncake.prepare_gradient_cache(Base.Fix1(sum, abs2), ones(Float32, 10))
+            # LuxTestUtils.MOONCAKE_TESTING_ENABLED[] = true
+            LuxTestUtils.MOONCAKE_TESTING_ENABLED[] = false
+        catch err
+            @error "`Mooncake.jl` did not successfully differentiate a simple function or \
+                    failed to load on $(VERSION). All Mooncake tests will be \
+                    skipped." maxlog = 1 err = err
+            LuxTestUtils.MOONCAKE_TESTING_ENABLED[] = false
+        end
+    end
+end
+
+function LuxTestUtils.gradient(f::F, ::AutoMooncake, args...) where {F}
+    return LuxTestUtils.gradient(f, mooncake_gradient_function, args...)
+end
+
+"""
+    mooncake_gradient_function(f, x)
+
+Compute gradient using Mooncake.jl's value_and_gradient!! function.
+Returns only the gradient for args x.
+"""
+function mooncake_gradient_function(f, x)
+    # Enable friendly_tangents for testing.
+    cache = Mooncake.prepare_gradient_cache(
+        f, x; config=Mooncake.Config(; friendly_tangents=true)
+    )
+    y, tangents = Mooncake.value_and_gradient!!(cache, f, x)
+    tangent_func, tangent_args = tangents
+    return tangent_args
+end
+
+end

--- a/lib/LuxTestUtils/src/LuxTestUtils.jl
+++ b/lib/LuxTestUtils/src/LuxTestUtils.jl
@@ -37,7 +37,6 @@ using ChainRulesCore: ChainRulesCore
 using FiniteDiff: FiniteDiff
 using ForwardDiff: ForwardDiff
 using Zygote: Zygote
-using Mooncake: Mooncake
 
 const CRC = ChainRulesCore
 const FD = FiniteDiff
@@ -57,7 +56,7 @@ catch err
     JET_TESTING_ENABLED[] = false
 end
 
-# Check if Mooncake & Enzyme will work (only on non-prerelease versions)
+# Check if Enzyme will work (only on non-prerelease versions)
 @static if isempty(VERSION.prerelease)
     try
         using Enzyme: Enzyme
@@ -68,19 +67,6 @@ end
                 failed to load on $(VERSION). All Enzyme tests will be \
                 skipped." maxlog = 1 err = err
         ENZYME_TESTING_ENABLED[] = false
-    end
-
-    try
-        # FIXME: Mooncake is currently wreaking havoc in the Lux repo test,
-        # dropping testing for now
-        # Mooncake.prepare_gradient_cache(Base.Fix1(sum, abs2), ones(Float32, 10))
-        # MOONCAKE_TESTING_ENABLED[] = true
-        MOONCAKE_TESTING_ENABLED[] = false
-    catch err
-        @error "`Mooncake.jl` did not successfully differentiate a simple function or \
-                failed to load on $(VERSION). All Mooncake tests will be \
-                skipped." maxlog = 1 err = err
-        MOONCAKE_TESTING_ENABLED[] = false
     end
 end
 

--- a/lib/LuxTestUtils/src/autodiff.jl
+++ b/lib/LuxTestUtils/src/autodiff.jl
@@ -74,26 +74,6 @@ function gradient(::F, ::AutoEnzyme{<:Enzyme.ForwardMode}, args...) where {F}
     return error("AutoEnzyme{ForwardMode} is not supported yet.")
 end
 
-function gradient(f::F, ::AutoMooncake, args...) where {F}
-    return gradient(f, mooncake_gradient_function, args...)
-end
-
-"""
-    mooncake_gradient_function(f, x)
-
-Compute gradient using Mooncake.jl's value_and_gradient!! function.
-Returns only the gradient for args x.
-"""
-function mooncake_gradient_function(f, x)
-    # Enable friendly_tangents for testing.
-    cache = Mooncake.prepare_gradient_cache(
-        f, x; config=Mooncake.Config(; friendly_tangents=true)
-    )
-    y, tangents = Mooncake.value_and_gradient!!(cache, f, x)
-    tangent_func, tangent_args = tangents
-    return tangent_args
-end
-
 # ForwardDiff.jl
 function gradient(f::F, ::AutoForwardDiff, args...) where {F}
     return gradient(f, ForwardDiff.gradient, args...)


### PR DESCRIPTION
Mooncake is needlessly causing an infinite timeout to instantiate on 1.10. This isn't enabled even at all for the moment, but regardless we can move it to an extension for when it is functional again.

```
root@linux-x86-n2-32-pcrnc-runner-tjwnr-workflow:/__w/Enzyme.jl/Enzyme.jl# julia --color=yes --project=test/integration/Lux --threads=auto --check-bounds=yes -O1 -e 'using Pkg; Pkg.instantiate()'                                                 
Precompiling packages...
    598.2 ms  ✓ EnzymeCore
    313.8 ms  ✓ EnzymeCore → AdaptExt
    309.4 ms  ✓ DispatchDoctor → DispatchDoctorEnzymeCoreExt
    310.4 ms  ✓ ADTypes → ADTypesEnzymeCoreExt
    364.0 ms  ✓ EnzymeCore → EnzymeCoreChainRulesCoreExt
    483.5 ms  ✓ LuxCore → EnzymeCoreExt
    546.8 ms  ✓ Optimisers → OptimisersEnzymeCoreExt
    567.9 ms  ✓ KernelAbstractions → EnzymeExt
    983.8 ms  ✓ NNlib → NNlibEnzymeCoreExt
   2959.9 ms  ✓ LuxLib
   1028.0 ms  ✓ LuxLib → ForwardDiffExt
  11271.2 ms  ✓ Lux
   1184.8 ms  ✓ Lux → ComponentArraysExt
   1701.0 ms  ✓ Lux → ZygoteExt

  32086.8 ms  ✓ Enzyme
    870.3 ms  ✓ LuxLib → EnzymeExt
    924.3 ms  ✓ Enzyme → EnzymeGPUArraysCoreExt
   1027.2 ms  ✓ Enzyme → EnzymeChainRulesCoreExt
   1056.9 ms  ✓ Enzyme → EnzymeLogExpFunctionsExt
   2062.3 ms  ✓ Enzyme → EnzymeSpecialFunctionsExt
  13661.8 ms  ✓ Enzyme → EnzymeStaticArraysExt
  14252.7 ms  ✓ Lux → EnzymeExt
  18174.0 ms  ✓ LuxTestUtils
^C           ✗ Lux → MooncakeExt
           ✗ Mooncake → MooncakeLuxLibExt
           ✗ Mooncake → MooncakeLuxLibNNlibExt
  23 dependencies successfully precompiled in 83 seconds. 153 already precompiled.

The following 1 direct dependency failed to precompile:

MooncakeExt 

Failed to precompile MooncakeExt [b1effcdf-857a-5cf3-9402-c6bb6acd029a] to "/root/.julia/compiled/v1.10/MooncakeExt/jl_icG0hc".
[1212] signal (2): Interrupt
in expression starting at /root/.julia/packages/Lux/ZSmgp/ext/MooncakeExt/MooncakeExt.jl:8
epoll_wait at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
uv__io_poll at /workspace/srcdir/libuv/src/unix/epoll.c:236
uv_run at /workspace/srcdir/libuv/src/unix/core.c:400
ijl_task_get_next at /cache/build/builder-amdci4-2/julialang/julia-release-1-dot-10/src/partr.c:478
poptask at ./task.jl:999
wait at ./task.jl:1008
#wait#647 at ./condition.jl:130
wait at ./condition.jl:125 [inlined]
wait at /cache/build/builder-amdci4-2/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/FileWatching/src/FileWatching.jl:661
watch_file at /cache/build/builder-amdci4-2/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/FileWatching/src/FileWatching.jl:772
watch_file at /cache/build/builder-amdci4-2/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/FileWatching/src/FileWatching.jl:778 [inlined]
#13 at /cache/build/builder-amdci4-2/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/FileWatching/src/pidfile.jl:260
unknown function (ip: 0x7fd0424816a9)
_jl_invoke at /cache/build/builder-amdci4-2/julialang/julia-release-1-dot-10/src/gf.c:2897 [inlined]
ijl_apply_generic at /cache/build/builder-amdci4-2/julialang/julia-release-1-dot-10/src/gf.c:3079
jl_apply at /cache/build/builder-amdci4-2/julialang/julia-release-1-dot-10/src/julia.h:1982 [inlined]
start_task at /cache/build/builder-amdci4-2/julialang/julia-release-1-dot-10/src/task.c:1253
unknown function (ip: (nil))
Allocations: 610907 (Pool: 609707; Big: 1200); GC: root@linux-x86-n2-32-pcrnc-runner-tjwnr-workflow:/__w/Enzyme.jl/Enzyme.jl#
```