### PR TITLE
fix: GPU-friendly conv gradients for generic devices (Metal, oneAPI)

### DIFF
--- a/lib/LuxLib/Project.toml
+++ b/lib/LuxLib/Project.toml
@@ -1,6 +1,6 @@
 name = "LuxLib"
 uuid = "82251201-b29d-42c6-8e01-566dec8acb11"
-version = "1.15.9"
+version = "1.15.10"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/LuxLib/src/impl/conv.jl
+++ b/lib/LuxLib/src/impl/conv.jl
@@ -125,14 +125,81 @@ function fallback_slow_conv(dev, x, weight, cdims::ConvDims)
     return y
 end
 
-function ∇conv_data(x′, weight′, cdims::ConvDims)
-    x, weight = get_conv_input_weight(x′, weight′)
-    return NNlib.∇conv_data(x, weight, cdims)
+function ∇conv_data(dy′, weight′, cdims::ConvDims)
+    dev = get_device_type((dy′, weight′))
+    dy, weight = get_conv_input_weight(dev, dy′, weight′)
+    return ∇conv_data(dev, dy, weight, cdims)
 end
 
-function ∇conv_filter(x′, y′, cdims::ConvDims)
-    x, y = get_conv_input_weight(x′, y′)
-    return NNlib.∇conv_filter(x, y, cdims)
+function ∇conv_data(
+    ::Type{<:Union{CPUDevice,CUDADevice,AMDGPUDevice,ReactantDevice}},
+    dy,
+    weight,
+    cdims::ConvDims,
+)
+    return NNlib.∇conv_data(dy, weight, cdims)
+end
+function ∇conv_data(dev::Type{<:AbstractDevice}, dy, weight, cdims::ConvDims)
+    return fallback_slow_∇conv_data(dev, dy, weight, cdims)
+end
+
+function ∇conv_filter(x′, dy′, cdims::ConvDims)
+    dev = get_device_type((x′, dy′))
+    x, dy = get_conv_input_weight(dev, x′, dy′)
+    return ∇conv_filter(dev, x, dy, cdims)
+end
+
+function ∇conv_filter(
+    ::Type{<:Union{CPUDevice,CUDADevice,AMDGPUDevice,ReactantDevice}},
+    x,
+    dy,
+    cdims::ConvDims,
+)
+    return NNlib.∇conv_filter(x, dy, cdims)
+end
+function ∇conv_filter(dev::Type{<:AbstractDevice}, x, dy, cdims::ConvDims)
+    return fallback_slow_∇conv_filter(dev, x, dy, cdims)
+end
+
+# NNlib's `∇conv_data`/`∇conv_filter` fall back to the CPU im2col routines for devices it
+# has no specialized kernels for, and those scalar-index the input arrays. Mirror
+# `fallback_slow_conv!` instead: both are the exact adjoints of `unfold`+`batched_matmul`,
+# expressed with `NNlib.fold` and `batched_matmul`, all of which are GPU friendly.
+
+function fallback_slow_∇conv_data(
+    dev, dy::AbstractArray{dyT,N}, weight::AbstractArray{wT,N}, cdims::ConvDims
+) where {dyT,wT,N}
+    @warn "Falling back to slow ∇conv_data routine for $(dev) with dy: size = \
+           $(size(dy)) eltype = $(dyT) and weight: size = $(size(weight)) \
+           eltype = $(wT)." maxlog = 1
+    @assert NNlib.groupcount(cdims) == 1 "Only groups=1 is supported for now." # FIXME
+    batchsize = size(dy, N)
+    dy_compact = reshape(dy, :, NNlib.channels_out(cdims), batchsize)
+    weight_compact = reshape(weight, :, size(weight, N), 1)
+    # contract over the output channels of both operands
+    dcol = batched_matmul(dy_compact, weight_compact; rhs_contracting_dim=2)
+    return NNlib.fold(
+        dcol, (NNlib.input_size(cdims)..., NNlib.channels_in(cdims), batchsize), cdims
+    )
+end
+
+function fallback_slow_∇conv_filter(
+    dev, x::AbstractArray{xT,N}, dy::AbstractArray{dyT,N}, cdims::ConvDims
+) where {xT,dyT,N}
+    @warn "Falling back to slow ∇conv_filter routine for $(dev) with x: size = \
+           $(size(x)) eltype = $(xT) and dy: size = $(size(dy)) \
+           eltype = $(dyT)." maxlog = 1
+    @assert NNlib.groupcount(cdims) == 1 "Only groups=1 is supported for now." # FIXME
+    tmp = NNlib.unfold(x, cdims)
+    dy_compact = reshape(dy, :, NNlib.channels_out(cdims), size(dy, N))
+    # contract over the spatial windows of both operands, then accumulate over the batch
+    dweight = batched_matmul(tmp, dy_compact; lhs_contracting_dim=1)
+    return reshape(
+        sum(dweight; dims=3),
+        NNlib.kernel_size(cdims)...,
+        NNlib.channels_in(cdims),
+        NNlib.channels_out(cdims),
+    )
 end
 
 function conv_bias_act(x′, weight′, cdims::ConvDims, bias′, act::F) where {F}

--- a/lib/LuxLib/test/common_ops/conv_tests.jl
+++ b/lib/LuxLib/test/common_ops/conv_tests.jl
@@ -92,11 +92,64 @@ const ALL_TEST_CONFIGS = Iterators.product(
     ),
 )
 
+# The generic-device path (Metal, oneAPI, ...) cannot use NNlib's im2col routines because
+# they scalar-index the input arrays. Check that the replacements agree with NNlib.
+const FALLBACK_TEST_CONFIGS = [
+    ((2,), (1,), (1,), 1),
+    ((1,), (0,), (1,), 1),
+    ((3,), (1,), (2,), 1),
+    ((2, 2), (1, 1), (1, 1), 1),
+    ((2, 2), (0, 0), (2, 2), 1),
+    ((3, 3), (2, 2), (1, 1), 1),
+    ((2, 2, 2), (1, 1, 1), (1, 1, 1), 1),
+]
+
+@testset "Slow Conv Fallbacks" begin
+    rng = StableRNG(12345)
+
+    @testset "kernel: $(kernel) padding: $(padding) stride: $(stride) flipkernel: $(flipkernel)" for (
+            kernel, padding, stride, groups
+        ) in FALLBACK_TEST_CONFIGS,
+        flipkernel in (true, false)
+
+        weight = convfilter(
+            (T, sz...) -> randn(rng, T, sz...), Float32, kernel, 4 => 8; groups
+        )
+        x = randn(rng, Float32, ntuple(Returns(6), length(kernel))..., 4, 2)
+
+        cdims = DenseConvDims(
+            x,
+            weight;
+            stride,
+            padding=calc_padding(padding, kernel, 1, stride),
+            dilation=1,
+            groups,
+            flipkernel,
+        )
+
+        y = NNlib.conv(x, weight, cdims)
+        dy = randn(rng, Float32, size(y)...)
+
+        # forward, for reference: this path is already exercised on Metal/oneAPI
+        @test LuxLib.Impl.fallback_slow_conv(CPUDevice, x, weight, cdims) ≈ y atol = 1.0f-3 rtol =
+            1.0f-3
+
+        ∂x = LuxLib.Impl.fallback_slow_∇conv_data(CPUDevice, dy, weight, cdims)
+        @test size(∂x) == size(x)
+        @test ∂x ≈ NNlib.∇conv_data(dy, weight, cdims) atol = 1.0f-3 rtol = 1.0f-3
+
+        ∂w = LuxLib.Impl.fallback_slow_∇conv_filter(CPUDevice, x, dy, cdims)
+        @test size(∂w) == size(weight)
+        @test ∂w ≈ NNlib.∇conv_filter(x, dy, cdims) atol = 1.0f-3 rtol = 1.0f-3
+    end
+end
+
 @testset "Fused Conv" begin
     @testset "$mode" for (mode, aType, ongpu, fp64) in MODES
         @testset "$(Tw) x $(Tx) hasbias: $(hasbias) activation: $(activation) kernel: $(kernel) padding: $(padding) stride: $(stride) groups: $(groups)" for (
-            (Tx, Tw), hasbias, activation, (kernel, padding, stride, groups)
-        ) in ALL_TEST_CONFIGS
+                (Tx, Tw), hasbias, activation, (kernel, padding, stride, groups)
+            ) in ALL_TEST_CONFIGS
+
             !fp64 && (Tx == Float64 || Tw == Float64) && continue
             run_conv_testing(
                 generate_fixed_array,


### PR DESCRIPTION
## Problem

`LuxLib.Impl.conv` dispatches on device: CPU/CUDA/AMDGPU/Reactant go to `NNlib.conv`, and everything else (Metal, oneAPI) goes to `fallback_slow_conv`, which is `NNlib.unfold` + `batched_matmul` and runs happily on the GPU.

The two backward entry points had no such dispatch:

```julia
function ∇conv_data(x′, weight′, cdims::ConvDims)
    x, weight = get_conv_input_weight(x′, weight′)
    return NNlib.∇conv_data(x, weight, cdims)     # always NNlib
end

function ∇conv_filter(x′, y′, cdims::ConvDims)
    x, y = get_conv_input_weight(x′, y′)
    return NNlib.∇conv_filter(x, y, cdims)        # always NNlib
end
```

On a device NNlib has no kernels for, these land in the CPU im2col routines, which scalar-index their arguments. So the forward pass succeeds (with the slow-path warning) and the pullback throws:

```julia
using Metal, Zygote, Random, Lux
rng = Random.default_rng(); dev = gpu_device()
x = MtlArray(randn(Float32, 32, 1, 128))
c = Conv((1,), 1 => 64)
ps, st = Lux.setup(rng, c) |> dev
Zygote.gradient(p -> sum(abs2, first(c(x, p, st))), ps)
```

```
┌ Warning: Falling back to slow convolution routine for MetalDevice ...
└ @ LuxLib.Impl .../impl/conv.jl:88
ERROR: Scalar indexing is disallowed.
 [10] im2col!(...)              @ NNlib .../impl/conv_im2col.jl:329
 [12] ∇conv_filter_im2col!(...) @ NNlib .../impl/conv_im2col.jl:179
```

Found while looking at [SciML/NeuralOperators.jl#150](https://github.com/SciML/NeuralOperators.jl/issues/150) (FNO fails to train on Metal). Metal.jl gained a native MPSGraph-backed FFT in 1.10, so the Fourier layers work now; this was the remaining blocker.

## Fix

Give `∇conv_data`/`∇conv_filter` the same device dispatch `conv` has, and write the generic-device fallbacks as the exact adjoints of the forward fallback:

* `fallback_slow_∇conv_data` contracts the cotangent against the weight over the output channels, then folds back with `NNlib.fold` (the documented adjoint of `unfold`, and it has a KernelAbstractions path for GPU arrays).
* `fallback_slow_∇conv_filter` contracts `unfold(x)` against the cotangent over the spatial windows, then accumulates over the batch.

Both use the `lhs_contracting_dim`/`rhs_contracting_dim` arguments `batched_matmul` already supports, so no `batched_transpose` wrappers are involved.

CPU, CUDA, AMDGPU and Reactant keep calling NNlib directly — that path is untouched.

Deriving the fallbacks as adjoints of the forward fallback rather than reimplementing the convolution math means `flipkernel`, stride, padding and dilation handling comes from `unfold`/`fold` and stays consistent with the forward pass by construction.

## Tests

New `Slow Conv Fallbacks` testset compares both fallbacks against NNlib on CPU across 1D/2D/3D kernels, strides, padding, and both `flipkernel` conventions (70 assertions). Running the fallbacks on CPU is what makes this meaningful in CI without a Metal runner.

`BACKEND_GROUP=cpu`, `lib/LuxLib/test/common_ops/conv_tests.jl`:

```
Test Summary:       | Pass  Total  Time
Slow Conv Fallbacks |   70     70  5.3s
Test Summary: | Pass  Total     Time
Fused Conv    |  192    192  1m30.6s
```

`BACKEND_GROUP=metal` on an M2 Max, same file:

| | Pass | Fail | Error |
|---|---|---|---|
| before | 58 | 8 | 12 |
| after | 64 | 8 | 6 |

The 6 fixed errors are all `Scalar indexing is disallowed`. What remains is pre-existing and unrelated to this PR:

* 6 × `AssertionError: Only groups=1 is supported for now.` — the existing limitation of `fallback_slow_conv!`, which fires in the forward pass. The new fallbacks carry the same `@assert` and the same `# FIXME`.
* 8 × `gelu_tanh` accuracy failures, identical before and after.

I also checked the fallbacks running on Metal against NNlib on CPU directly (10 configurations, 1D/2D, strided, both `flipkernel` values) — all match to `2f-3`.

End to end, the FNO from SciML/NeuralOperators.jl#150 now trains on Metal:

```
epoch 1   loss = 1.380443
epoch 5   loss = 0.31330946
epoch 10  loss = 0.18256193
epoch 15  loss = 0.11643389
epoch 20  loss = 0.049909823
```

## Notes

Version bumped to `1.15.10`.

Worth saying explicitly: this makes the generic-device path *correct*, not fast. `∇conv_filter` materializes `unfold(x)` and `batched_matmul`'s permutation of it. Metal.jl does wrap MPSGraph convolution including both gradients in `lib/mpsgraphs/nn.jl`, so a real fast path is possible later — it would need the 2D-only `MPSGraphConvolution2DOpDescriptor` bridged to NNlib's interface. Grouped convolutions on these devices remain unsupported, in the forward pass as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
