### PR TITLE
docs: document SamePad padding

### DIFF
--- a/docs/src/api/Lux/layers.md
+++ b/docs/src/api/Lux/layers.md
@@ -21,6 +21,7 @@ AlternatePrecision
 ```@docs
 Conv
 ConvTranspose
+SamePad
 ```
 
 ## Dropout Layers

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -1,3 +1,30 @@
+"""
+    SamePad()
+
+A padding specification for convolutional and pooling layers that preserves the spatial
+shape when `stride == 1`.
+
+Pass `SamePad()` as the `pad` keyword argument to [`Conv`](@ref), [`ConvTranspose`](@ref),
+or a pooling layer. Lux derives a possibly asymmetric zero-padding tuple from the effective
+kernel size, including dilation. For a forward convolution or pooling layer, each spatial
+output dimension is `cld(input_dimension, stride)`; for a transposed convolution, it is
+`input_dimension * stride` up to the layer's `outpad` setting.
+
+## Fields
+
+`SamePad` is a singleton marker type and has no fields.
+
+## Examples
+
+```julia
+julia> using Lux, Random
+
+julia> layer = Conv((3, 3), 3 => 8; pad=SamePad());
+
+julia> size(layer(rand(Float32, 16, 16, 3, 2), Lux.setup(Random.default_rng(), layer)...)[1])
+(16, 16, 8, 2)
+```
+"""
 struct SamePad end
 
 function calc_padding(pad, ::NTuple{N}, dilation, stride) where {N}

--- a/test/core_layers/conv_tests.jl
+++ b/test/core_layers/conv_tests.jl
@@ -3,7 +3,7 @@ include("../shared_testsetup.jl")
 @testset "Conv" begin
     rng = StableRNG(12345)
 
-    @test Base.Docs.hasdoc(Lux, :SamePad)
+    @test haskey(Base.Docs.meta(Lux), Base.Docs.Binding(Lux, :SamePad))
 
     @testset "$mode" for (mode, aType, dev, ongpu) in MODES
         @testset "Grouped Conv" begin

--- a/test/core_layers/conv_tests.jl
+++ b/test/core_layers/conv_tests.jl
@@ -3,6 +3,8 @@ include("../shared_testsetup.jl")
 @testset "Conv" begin
     rng = StableRNG(12345)
 
+    @test Base.Docs.hasdoc(Lux, :SamePad)
+
     @testset "$mode" for (mode, aType, dev, ongpu) in MODES
         @testset "Grouped Conv" begin
             x = aType(rand(rng, Float32, 4, 6, 1))


### PR DESCRIPTION
Adds a SciMLStyle source docstring for the exported `SamePad` padding marker at its original Lux definition and includes it on the rendered layers API page. A focused regression assertion ensures the public binding retains a docstring.

## Verification

Before this change:

```text
julia --startup-file=no --project=. -e 'using Lux; @assert Base.Docs.hasdoc(Lux, :SamePad)'
ERROR: AssertionError: Base.Docs.hasdoc(Lux, :SamePad)
```

After this change:

```text
SamePad docstring present
SamePad documentation example passed
julia --startup-file=no --project=test test/runtests.jl --BACKEND_GROUP=cpu core_layers/conv_tests
Test Summary: | Pass  Total     Time
  Overall     |  493    493  9m02.0s
```

Also passed `JuliaFormatter` v1, `typos src/layers/conv.jl docs/src/api/Lux/layers.md test/core_layers/conv_tests.jl`, and `git diff --check`.

`julia --startup-file=no --project=docs docs/make.jl` ran through the `SamePad` API entry but does not complete because the current checkout has unrelated Documenter errors for `LuxTestUtils.mooncake_gradient_function`, an Optimization tutorial reference, and NNlib bindings omitted from the manual. No docs checks were disabled or made warn-only.

Ignore this PR until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791
