### PR TITLE
docs: document SamePad padding marker

### DIFF
--- a/docs/src/api/Lux/layers.md
+++ b/docs/src/api/Lux/layers.md
@@ -19,6 +19,7 @@ AlternatePrecision
 ## Convolutional Layers
 
 ```@docs
+SamePad
 Conv
 ConvTranspose
 ```

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -1,3 +1,13 @@
+"""
+    SamePad()
+
+Padding marker for convolution and pooling layers that automatically chooses padding from
+the kernel or window size and dilation. With `stride = 1`, `pad = SamePad()` preserves each
+spatial input dimension. For larger strides, convolution and pooling output dimensions are
+the corresponding input dimensions divided by the stride and rounded up.
+
+See also [`Conv`](@ref), [`ConvTranspose`](@ref), [`MaxPool`](@ref), and [`MeanPool`](@ref).
+"""
 struct SamePad end
 
 function calc_padding(pad, ::NTuple{N}, dilation, stride) where {N}

--- a/test/misc/qa_tests.jl
+++ b/test/misc/qa_tests.jl
@@ -3,7 +3,7 @@ using Lux, LuxCore, LuxLib, MLDataDevices
 using ComponentArrays, ReverseDiff, Tracker, Zygote, Enzyme, Reactant, Mooncake
 
 @testset "Public API documentation" begin
-    @test Base.Docs.hasdoc(Lux, :SamePad)
+    @test haskey(Base.Docs.meta(Lux), Base.Docs.Binding(Lux, :SamePad))
 end
 
 @testset "Aqua: Quality Assurance" begin

--- a/test/misc/qa_tests.jl
+++ b/test/misc/qa_tests.jl
@@ -2,6 +2,10 @@ using Aqua, ChainRulesCore, ForwardDiff, Test, ExplicitImports
 using Lux, LuxCore, LuxLib, MLDataDevices
 using ComponentArrays, ReverseDiff, Tracker, Zygote, Enzyme, Reactant, Mooncake
 
+@testset "Public API documentation" begin
+    @test Base.Docs.hasdoc(Lux, :SamePad)
+end
+
 @testset "Aqua: Quality Assurance" begin
     Aqua.test_all(
         Lux; ambiguities=false, piracies=false, unbound_args=false, persistent_tasks=false


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`Lux.SamePad` is exported and part of Lux's public API, but it had no owner docstring or rendered API entry. This adds both at the definition, renders `SamePad` with the convolutional layer API, and adds a binding-level documentation regression test. This fixes downstream documentation QA without adding an ignore-list exception.

This documents existing API and does not change runtime behavior. After the first Lux release containing this change exists, downstream packages such as DiffEqFlux should raise their Lux compat floor to that release so minimum-version QA receives the documentation fix.

## Verification

The final binding assertion fails against the unfixed source on Julia 1.10.11:

```console
$ julia +1.10 --startup-file=no --project=test -e 'using Lux, Test; @test haskey(Base.Docs.meta(Lux), Base.Docs.Binding(Lux, :SamePad))'
Test Failed at none:1
  Expression: haskey(Base.Docs.meta(Lux), Base.Docs.Binding(Lux, :SamePad))
ERROR: There was an error during testing
```

The exact command exits 0 with the docstring applied. The full Julia 1.10 QA shard then passes:

```console
$ julia +1.10 --startup-file=no --project=test test/runtests.jl --jobs=1 --BACKEND_GROUP=CPU misc/qa_tests
Test Summary: | Pass  Broken  Total     Time
  Overall     |   15       3     18  1m51.2s
    SUCCESS
```

The initial full QA discriminator on Julia 1.12.7 also failed before and passed after the docstring:

```console
# Before
Test Summary: | Pass  Fail  Broken  Total     Time
  Overall     |   14     1       3     18  1m33.2s
ERROR: LoadError: Some tests failed: 14 passed, 1 failed, 0 errored, 3 broken.

# After
Test Summary: | Pass  Broken  Total     Time
  Overall     |   15       3     18  4m03.5s
    SUCCESS
```

Relevant convolution tests passed:

```console
$ julia +release --startup-file=no --project=test test/runtests.jl core_layers/conv_tests
Test Summary: | Pass  Total
  Overall     |  492    492
    SUCCESS
```

The normal, non-draft docs build passed on Julia 1.11.9 after generating the same Optimization tutorial artifact that the documentation workflow supplies before `docs/make.jl`:

```console
$ julia +1.11 --startup-file=no --project=docs docs/make.jl
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
build complete in 28.22s.
```

JuliaFormatter v1, spelling, and whitespace checks passed on the final diff:

```console
$ julia +1.12 --startup-file=no --project=.juliaformatter-1 -e 'using JuliaFormatter; format("test/misc/qa_tests.jl")'
$ typos docs/src/api/Lux/layers.md src/layers/conv.jl test/misc/qa_tests.jl
$ git diff --check
```

## CI notes and gaps

The first CI revision exposed that `Base.Docs.hasdoc` is unavailable on Julia 1.10; the final assertion uses the cross-version documentation metadata API and is covered by the passing local Julia 1.10 shard above. The AirspeedVelocity job cannot post its benchmark comment from this fork and fails with GitHub's `Resource not accessible by integration` 403; benchmark execution itself is unrelated to this documentation-only diff.

The six full tutorial shards, GPU jobs, downstream packages, and prerelease Julia were not run locally. The local CPU tutorial shard generated and executed `OptimizationIntegration` and `GCN_Cora`, then reached the one-hour shell bound while compiling the unrelated `GravitationalWaveForm` tutorial; the generated Optimization artifact was sufficient for the normal docs build above.

## Links

- Julia 1.10 CI failure from the first assertion: https://github.com/LuxDL/Lux.jl/actions/runs/33297222926/job/99218869934
- Fork-token benchmark comment failure: https://github.com/LuxDL/Lux.jl/actions/runs/33297222839/job/99218869371

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: /home/crackauc/.codex/sessions/2026/08/29/rollout-2026-08-29T20-41-15-01a0501d-0879-7f80-b479-de442568c09d.jsonl, local transcript path)
