### PR TITLE
feat(layers): Add GroupedQueryAttention (GQA) layer

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -101,3 +101,21 @@
     title     = {Group normalization},
     year      = {2018}
 }
+
+@inproceedings{ainslie2023gqa,
+    title = "{GQA}: Training Generalized Multi-Query Transformer Models from Multi-Head Checkpoints",
+    author = "Ainslie, Joshua  and
+      Lee-Thorp, James  and
+      de Jong, Michiel  and
+      Zemlyanskiy, Yury  and
+      Lebron, Federico  and
+      Sanghai, Sumit",
+    editor = "Bouamor, Houda  and
+      Pino, Juan  and
+      Bali, Kalika",
+    booktitle = "Proceedings of the 2023 Conference on Empirical Methods in Natural Language Processing",
+    month = dec,
+    year = "2023",
+   }
+
+how to 

--- a/src/layers/attention.jl
+++ b/src/layers/attention.jl
@@ -119,10 +119,31 @@ function Base.show(io::IO, ::MIME"text/plain", mha::MultiHeadAttention)
     return nothing
 end
 
+"""
+    parse_mha_dims(dims::IntegerType) -> NamedTuple
+
+Parse a single uniform dimension specification for standard Multi-Head Attention (MHA).
+
+Sets all feature dimensions—input (`q_in`, `k_in`, `v_in`), intermediate projections 
+(`qk`, `v`), and final output (`out`)—to `dims`.
+"""
 function parse_mha_dims(dims::IntegerType)
     return (; q_in=dims, k_in=dims, v_in=dims, qk=dims, v=dims, out=dims)
 end
 
+"""
+    parse_mha_dims((in_dims, (qkv_dims, out_dims))) -> NamedTuple
+
+Parse flexible or heterogeneous dimension specifications for Multi-Head Attention.
+
+# Inputs
+- `in_dims`: Integer (shared for Q/K/V) or `NTuple{3, Integer}` `(q_in, k_in, v_in)` for cross-attention.
+- `qkv_dims`: Integer (shared projection size for QK and V) or `NTuple{2, Integer}` `(qk, v)`.
+- `out_dims`: Integer dimension for the final output linear projection.
+
+# Returns
+A `NamedTuple` with keys `(; q_in, k_in, v_in, qk, v, out)`.
+"""
 function parse_mha_dims((in_dims, (qkv_dims, out_dims)))
     if in_dims isa IntegerType
         q_in, k_in, v_in = in_dims, in_dims, in_dims
@@ -284,14 +305,22 @@ end
 function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, q, k, v, mask=nothing)
     q, k, v = match_eltype(gqa, ps, st, q, k, v)
 
+    # Linear projection into attention feature space
+    # Output shapes:
+    #   q: (head_dim_qk * nqheads, seq_len, batch)
+    #   k: (head_dim_qk * nkvheads, seq_len, batch)
+    #   v: (head_dim_v  * nkvheads, seq_len, batch)
     q, q_st = gqa.q_proj(q, ps.q_proj, st.q_proj)
     k, k_st = gqa.k_proj(k, ps.k_proj, st.k_proj)
     v, v_st = gqa.v_proj(v, ps.v_proj, st.v_proj)
 
+    # Wrap dropout in stateful layer to avoid manual threading of parameters
     dropout = StatefulLuxLayer(
         gqa.attention_dropout, ps.attention_dropout, st.attention_dropout
     )
 
+    # Scaled Dot Product Attention Kernel
+    # Yields context x: (head_dim, nqheads, q_len, batch) and attention weights α
     x, α = scaled_dot_product_attention(
         reshape(q, size(q, 1) ÷ gqa.nqheads,  gqa.nqheads,  size(q)[2:end]...),
         reshape(k, size(k, 1) ÷ gqa.nkvheads, gqa.nkvheads, size(k)[2:end]...), # Uses nkvheads

--- a/src/layers/attention.jl
+++ b/src/layers/attention.jl
@@ -92,20 +92,21 @@ julia> size(α)
 
 """
 @concrete struct MultiHeadAttention <: AbstractLuxContainerLayer{(
-    :q_proj, :k_proj, :v_proj, :attention_dropout, :out_proj
+    :q_proj, :k_proj, :v_proj, :attention_dropout, :out_proj # specifiying which struct fields are lyaers to generate ps and st trees
 ),}
-    nheads <: IntegerType
-    q_proj <: Dense
-    k_proj <: Dense
-    v_proj <: Dense
+    nheads <: IntegerType # number of attention heads
+    q_proj <: Dense # query projection layer (W_q)
+    k_proj <: Dense # key projection layer (W_k)
+    v_proj <: Dense # value projection layer (W_v)
     attention_dropout
-    out_proj <: Dense
-    is_causal <: Union{Bool,Nothing}
+    out_proj <: Dense # output projection layer (W_o)
+    is_causal <: Union{Bool,Nothing} # causal mask flag 
 end
 
 function Base.show(io::IO, ::MIME"text/plain", mha::MultiHeadAttention)
     q_in, k_in, v_in = mha.q_proj.in_dims, mha.k_proj.in_dims, mha.v_proj.in_dims
     out_dim = mha.out_proj.out_dims
+
     attention_dropout_probability =
         mha.attention_dropout isa NoOpLayer ? 0.0f0 : mha.attention_dropout.p
     print(
@@ -142,7 +143,7 @@ end
 
 function MultiHeadAttention(
     dims;
-    nheads::IntegerType=1,
+    nheads::IntegerType=1, # defaults to single head attention
     dense_kwargs=(; use_bias=False()),
     attention_dropout_probability=0.0f0,
     is_causal::Union{Bool,Nothing}=nothing,
@@ -178,29 +179,133 @@ function apply_multiheadattention(mha::MultiHeadAttention, ps, st, q, kv)
 end
 
 function apply_multiheadattention(mha::MultiHeadAttention, ps, st, q, k, v, mask=nothing)
-    q, k, v = match_eltype(mha, ps, st, q, k, v)
+    q, k, v = match_eltype(mha, ps, st, q, k, v) # ensuring q, k, v have the same eltype as layer's parameters
 
+    # apply linear transformation to map raw inputs into query, key and value feature spaces
     q, q_st = mha.q_proj(q, ps.q_proj, st.q_proj)
     k, k_st = mha.k_proj(k, ps.k_proj, st.k_proj)
     v, v_st = mha.v_proj(v, ps.v_proj, st.v_proj)
 
     dropout = StatefulLuxLayer(
         mha.attention_dropout, ps.attention_dropout, st.attention_dropout
+    ) # statefulLuxLayer avoids passing ps and st to the dropout layer
+
+    x, α = scaled_dot_product_attention(
+        reshape(q, size(q, 1) ÷ mha.nheads, mha.nheads, size(q)[2:end]...), # [q_out_dim, seq_len, batch] -> [head_dim, nheads, seq_len, batch]
+        reshape(k, size(k, 1) ÷ mha.nheads, mha.nheads, size(k)[2:end]...),
+        reshape(v, size(v, 1) ÷ mha.nheads, mha.nheads, size(v)[2:end]...);
+        head_dim=1, # feature vectors per head are along the first dimension
+        token_dim=3, # se_len (num tokens) dimension is along the 3rd dimension
+        fdrop=dropout,
+        mask,
+        mha.is_causal,
+    ) # x: output attention tensor, α: attention weights (softmax probabilities)
+    x = reshape(x, size(x, 1) * mha.nheads, size(x)[3:end]...) # head_dim * nheads. [q_out_dim, seq_len, batch]
+
+    y, out_st = mha.out_proj(x, ps.out_proj, st.out_proj)
+
+    return (
+        (y, α),
+        (;
+            q_proj=q_st,
+            k_proj=k_st,
+            v_proj=v_st,
+            attention_dropout=dropout.st,
+            out_proj=out_st,
+        ),
+    )
+end
+
+
+
+@concrete struct GroupQueryAttention <: AbstractLuxContainerLayer{(
+    :q_proj, :k_proj, :v_proj, :attention_dropout, :out_proj
+),}
+    nqheads <: IntegerType
+    nkvheads <: IntegerType
+    q_proj <: Dense
+    k_proj <: Dense
+    v_proj <: Dense
+    attention_dropout
+    out_proj <: Dense
+    is_causal <: Union{Bool,Nothing}
+end
+
+function GroupQueryAttention(
+    dims;
+    nqheads::IntegerType,
+    nkvheads::IntegerType,
+    dense_kwargs=(; use_bias=False()),
+    attention_dropout_probability=0.0f0,
+    is_causal::Union{Bool,Nothing}=nothing,
+)
+    @assert nqheads % nkvheads == 0 "nqheads ($nqheads) must be divisible by nkvheads ($nkvheads)"
+
+    parsed_dims = parse_mha_dims(dims)
+    @assert parsed_dims.qk % nqheads == 0 "qk_dim must be divisible by nqheads"
+    @assert parsed_dims.v % nqheads == 0 "v_dim must be divisible by nqheads"
+
+    # Per-head dimension calculations
+    head_dim_qk = parsed_dims.qk ÷ nqheads
+    head_dim_v  = parsed_dims.v ÷ nqheads
+
+    # Key and Value target output dimensions
+    k_out_dim = head_dim_qk * nkvheads
+    v_out_dim = head_dim_v * nkvheads
+
+    return GroupQueryAttention(
+        nqheads,
+        nkvheads,
+        Dense(parsed_dims.q_in, parsed_dims.qk; dense_kwargs...),
+        Dense(parsed_dims.k_in, k_out_dim; dense_kwargs...),
+        Dense(parsed_dims.v_in, v_out_dim; dense_kwargs...),
+        Dropout(attention_dropout_probability),
+        Dense(parsed_dims.v, parsed_dims.out; dense_kwargs...), # Inputs from parsed_dims.v (head_dim_v * nqheads)
+        is_causal,
+    )
+end
+
+@trace function (gqa::GroupQueryAttention)(x, ps, st::NamedTuple)
+    return apply_groupqueryattention(gqa, ps, st, x)
+end
+
+@trace function (gqa::GroupQueryAttention)(x::Tuple, ps, st::NamedTuple)
+    return apply_groupqueryattention(gqa, ps, st, x...)
+end
+
+function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, qkv)
+    return apply_groupqueryattention(gqa, ps, st, qkv, qkv, qkv, nothing)
+end
+
+function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, q, kv)
+    return apply_groupqueryattention(gqa, ps, st, q, kv, kv, nothing)
+end
+
+function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, q, k, v, mask=nothing)
+    q, k, v = match_eltype(gqa, ps, st, q, k, v)
+
+    q, q_st = gqa.q_proj(q, ps.q_proj, st.q_proj)
+    k, k_st = gqa.k_proj(k, ps.k_proj, st.k_proj)
+    v, v_st = gqa.v_proj(v, ps.v_proj, st.v_proj)
+
+    dropout = StatefulLuxLayer(
+        gqa.attention_dropout, ps.attention_dropout, st.attention_dropout
     )
 
     x, α = scaled_dot_product_attention(
-        reshape(q, size(q, 1) ÷ mha.nheads, mha.nheads, size(q)[2:end]...),
-        reshape(k, size(k, 1) ÷ mha.nheads, mha.nheads, size(k)[2:end]...),
-        reshape(v, size(v, 1) ÷ mha.nheads, mha.nheads, size(v)[2:end]...);
+        reshape(q, size(q, 1) ÷ gqa.nqheads,  gqa.nqheads,  size(q)[2:end]...),
+        reshape(k, size(k, 1) ÷ gqa.nkvheads, gqa.nkvheads, size(k)[2:end]...), # Uses nkvheads
+        reshape(v, size(v, 1) ÷ gqa.nkvheads, gqa.nkvheads, size(v)[2:end]...); # Uses nkvheads
         head_dim=1,
         token_dim=3,
         fdrop=dropout,
         mask,
-        mha.is_causal,
+        gqa.is_causal,
     )
-    x = reshape(x, size(x, 1) * mha.nheads, size(x)[3:end]...)
 
-    y, out_st = mha.out_proj(x, ps.out_proj, st.out_proj)
+    x = reshape(x, size(x, 1) * gqa.nqheads, size(x)[3:end]...)
+
+    y, out_st = gqa.out_proj(x, ps.out_proj, st.out_proj)
 
     return (
         (y, α),

--- a/src/layers/attention.jl
+++ b/src/layers/attention.jl
@@ -1,5 +1,6 @@
 # Major parts of this file are adapted from the following sources:
 #   1. https://github.com/FluxML/Flux.jl/blob/fa108bb994a2cc839240d8497c9e1610818a49ab/src/layers/attention.jl
+export MultiHeadAttention, GroupQueryAttention
 """
     MultiHeadAttention(dims; nheads=1, dense_kwargs=(; use_bias=False()),
                        attention_dropout_probability=0.0f0,
@@ -92,7 +93,7 @@ julia> size(α)
 
 """
 @concrete struct MultiHeadAttention <: AbstractLuxContainerLayer{(
-    :q_proj, :k_proj, :v_proj, :attention_dropout, :out_proj # specifiying which struct fields are lyaers to generate ps and st trees
+    :q_proj, :k_proj, :v_proj, :attention_dropout, :out_proj # specifiying which struct fields are layers to generate ps and st trees
 ),}
     nheads <: IntegerType # number of attention heads
     q_proj <: Dense # query projection layer (W_q)
@@ -239,6 +240,99 @@ end
 
 
 
+"""
+    GroupQueryAttention(dims; nqheads::IntegerType, nkvheads::IntegerType,
+                        dense_kwargs=(; use_bias=False()),
+                        attention_dropout_probability=0.0f0,
+                        is_causal::Union{Bool,Nothing}=nothing)
+
+The grouped-query attention layer used in modern Transformer architectures
+[ainslie2023gqa](@citep).
+
+## Arguments
+
+  - `dims`: The embedding dimensions of inputs, intermediate tensors and outputs.
+    In the most general case, it is given as
+
+    + a) `(q_in_dim, k_in_dim, v_in_dim) => (qk_dim, v_dim) => out_dim`.
+
+    Can take also simpler forms as
+
+    + b) `dims::Int`;
+    + c) `in_dim::Int => (qk_dim, v_dim) => out_dim`;
+    + d) `in_dim::Int => qkv_dim => out_dim`.
+
+## Keyword Arguments
+
+  - `nqheads`: number of query heads.
+  - `nkvheads`: number of key and value heads (must evenly divide `nqheads`).
+  - `attention_dropout_probability`: dropout probability for the attention scores.
+  - `dense_kwargs`: keyword arguments for the Dense layers. Default `use_bias=false`.
+  - `is_causal`: whether the attention is causal. If this is provided, the attention mask
+    will be automatically created (passing in the `mask` argument is not allowed and will
+    throw an error).
+
+## Forward Pass Signature(s)
+
+```julia
+(m::GroupQueryAttention)(qkv, ps, st::NamedTuple)
+(m::GroupQueryAttention)((q, kv), ps, st::NamedTuple)
+(m::GroupQueryAttention)((q, k, v, [mask = nothing]), ps, st::NamedTuple)
+```
+
+## Inputs
+#
+#   - `qkv`: A single input tensor for query, key, and value. This corresponds to
+#     self-attention.
+#   - `(q, kv)`: A tuple of two input tensors for query and key-value.
+#   - `(q, k, v)`: A tuple of three input tensors for query, key, and value.
+#   - `mask`: An optional mask to apply to the attention scores. This must be broadcastable
+#     to the shape of the attention scores `(kv_len, q_len, nqheads, batch_size)`.
+#
+# The query tensor `q` is expected to have shape `(q_in_dim, q_len, batch_size)`, the
+# key tensor `k` is expected to have shape `(k_in_dim, kv_len, batch_size)`, and the
+# value tensor `v` is expected to have shape `(v_in_dim, kv_len, batch_size)`.
+#
+## Returns
+#
+#   - A tuple of two elements:
+#     1. The output tensor of shape `(out_dim, q_len, batch_size)`.
+#     2. The attention scores of shape `(kv_len, q_len, nqheads, batch_size)`.
+#   - A NamedTuple of the states of the layer.
+#
+# Extended Help
+#
+## Examples
+```jldoctest
+julia> m = GroupQueryAttention(64; nqheads=8, nkvheads=2);
+
+julia> ps, st = Lux.setup(Random.default_rng(), m);
+
+julia> q = randn(Float32, 64, 10, 32);
+
+julia> k = randn(Float32, 64, 20, 32);
+
+julia> v = randn(Float32, 64, 20, 32);
+
+julia> (y, α), st_new = m((q, k, v), ps, st);
+
+julia> size(y)
+(64, 10, 32)
+
+julia> size(α)
+(20, 10, 8, 32)
+
+julia> (y, α), st_new = m(q, ps, st);  # self-attention
+
+julia> size(y)
+(64, 10, 32)
+
+julia> size(α)
+(10, 10, 8, 32)
+```
+
+"""
+
 @concrete struct GroupQueryAttention <: AbstractLuxContainerLayer{(
     :q_proj, :k_proj, :v_proj, :attention_dropout, :out_proj
 ),}
@@ -250,6 +344,22 @@ end
     attention_dropout
     out_proj <: Dense
     is_causal <: Union{Bool,Nothing}
+end
+
+function Base.show(io::IO, ::MIME"text/plain", gqa::GroupQueryAttention)
+    q_in, k_in, v_in = gqa.q_proj.in_dims, gqa.k_proj.in_dims, gqa.v_proj.in_dims
+    out_dim = gqa.out_proj.out_dims
+
+    attention_dropout_probability =
+        gqa.attention_dropout isa NoOpLayer ? 0.0f0 : gqa.attention_dropout.p
+    print(
+        io, "GroupQueryAttention($q_in => ($k_in, $v_in) => $out_dim; nqheads=$(gqa.nqheads), nkvheads=$(gqa.nkvheads)"
+    )
+    !iszero(attention_dropout_probability) &&
+        print(io, ", attention_dropout_probability=$(attention_dropout_probability)")
+    gqa.is_causal !== nothing && print(io, ", is_causal=$(gqa.is_causal)")
+    print(io, ")")
+    return nothing
 end
 
 function GroupQueryAttention(
@@ -286,26 +396,28 @@ function GroupQueryAttention(
     )
 end
 
-@trace function (gqa::GroupQueryAttention)(x, ps, st::NamedTuple)
+@trace function (gqa::GroupQueryAttention)(x, ps, st::NamedTuple) # Self-Attention
     return apply_groupqueryattention(gqa, ps, st, x)
 end
 
-@trace function (gqa::GroupQueryAttention)(x::Tuple, ps, st::NamedTuple)
+@trace function (gqa::GroupQueryAttention)(x::Tuple, ps, st::NamedTuple) # Cross-Attention
     return apply_groupqueryattention(gqa, ps, st, x...)
 end
 
-function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, qkv)
+function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, qkv) # Self-Attention
     return apply_groupqueryattention(gqa, ps, st, qkv, qkv, qkv, nothing)
 end
 
-function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, q, kv)
+function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, q, kv) # Shared KV Cross-Attention
     return apply_groupqueryattention(gqa, ps, st, q, kv, kv, nothing)
 end
 
 function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, q, k, v, mask=nothing)
+    # 1. Type Precision Alignment
+    # Casts q, k, v element types to match layer parameters (e.g., Float16 for low-VRAM inference)
     q, k, v = match_eltype(gqa, ps, st, q, k, v)
 
-    # Linear projection into attention feature space
+    # 2. Linear projection into attention feature space
     # Output shapes:
     #   q: (head_dim_qk * nqheads, seq_len, batch)
     #   k: (head_dim_qk * nkvheads, seq_len, batch)
@@ -314,13 +426,15 @@ function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, q, k, v, ma
     k, k_st = gqa.k_proj(k, ps.k_proj, st.k_proj)
     v, v_st = gqa.v_proj(v, ps.v_proj, st.v_proj)
 
-    # Wrap dropout in stateful layer to avoid manual threading of parameters
+    # 3. Stateful Layer Encapsulation
+    # Wraps attention dropout layer to isolate parameter and RNG state management
     dropout = StatefulLuxLayer(
         gqa.attention_dropout, ps.attention_dropout, st.attention_dropout
     )
 
-    # Scaled Dot Product Attention Kernel
-    # Yields context x: (head_dim, nqheads, q_len, batch) and attention weights α
+    # 4. Reshape to 4D Multi-Head Formats & Scaled Dot-Product Attention
+    # Unflattens feature dimension: (embed_dim, seq_len, batch) -> (head_dim, n_heads, seq_len, batch)
+    # Standard SDPA handles GQA broadcasting when nqheads is a multiple of nkvheads
     x, α = scaled_dot_product_attention(
         reshape(q, size(q, 1) ÷ gqa.nqheads,  gqa.nqheads,  size(q)[2:end]...),
         reshape(k, size(k, 1) ÷ gqa.nkvheads, gqa.nkvheads, size(k)[2:end]...), # Uses nkvheads
@@ -332,12 +446,17 @@ function apply_groupqueryattention(gqa::GroupQueryAttention, ps, st, q, k, v, ma
         gqa.is_causal,
     )
 
+    # 5. Concatenate Multi-Head Attention Context Outputs
+    # Flattens back to 3D: (head_dim * nqheads, q_len, batch)
     x = reshape(x, size(x, 1) * gqa.nqheads, size(x)[3:end]...)
 
+    # 6. Final Linear Output Projection (W_o)
+    # Maps concatenated head outputs to out_dim: (out_dim, q_len, batch)
     y, out_st = gqa.out_proj(x, ps.out_proj, st.out_proj)
 
+    # 7. Return Tuple & Updated Layer State Tree
     return (
-        (y, α),
+        (y, α), # Output tensor y and attention weight matrix α
         (;
             q_proj=q_st,
             k_proj=k_st,

--- a/test/core_layers/attention_tests.jl
+++ b/test/core_layers/attention_tests.jl
@@ -1,4 +1,14 @@
+using Pkg
+ENV["GROUP"] = "CPU"  # Options are usually "CPU", "CUDA", "AMDGPU", "Metal", or "ALL"
+ENV["AUTODIFF_BACKENDS"] = "Zygote,ForwardDiff"
+Pkg.activate("test")
+Pkg.instantiate()
 using NNlib
+using Test
+using Lux
+using LuxLib
+using Random
+
 
 include("../shared_testsetup.jl")
 
@@ -63,3 +73,178 @@ include("../shared_testsetup.jl")
         @test_gradients(loss, mha, (q, k, v), ps, st; atol=1.0f-3, rtol=1.0f-3)
     end
 end
+
+
+
+rng = Random.default_rng()
+Random.seed!(rng, 42)
+
+@testset "GroupQueryAttention Implementation Tests" begin
+
+    @testset "Constructor & Assertion Guardrails" begin
+        # 1. Valid GQA construction
+        gqa = GroupQueryAttention(64; nqheads=8, nkvheads=2)
+        @test gqa isa AbstractLuxContainerLayer
+        @test gqa.nqheads == 8
+        @test gqa.nkvheads == 2
+
+        # 2. Invalid head ratio: nqheads (8) not divisible by nkvheads (3)
+        @test_throws AssertionError GroupQueryAttention(64; nqheads=8, nkvheads=3)
+
+        # 3. Invalid dimension: qk_dim (64) not divisible by nqheads (10)
+        @test_throws AssertionError GroupQueryAttention(64; nqheads=10, nkvheads=2)
+    end
+
+    @testset "Shape Verification & Input Signatures" begin
+        embed_dim = 64
+        q_len = 12
+        kv_len = 18
+        batch_size = 4
+        nqheads = 8
+        nkvheads = 2
+
+        gqa = GroupQueryAttention(embed_dim; nqheads=nqheads, nkvheads=nkvheads)
+        ps, st = Lux.setup(rng, gqa)
+
+        q = randn(Float32, embed_dim, q_len, batch_size)
+        k = randn(Float32, embed_dim, kv_len, batch_size)
+        v = randn(Float32, embed_dim, kv_len, batch_size)
+
+        # Single input (Self-Attention)
+        (y_self, α_self), st_self = gqa(q, ps, st)
+        @test size(y_self) == (embed_dim, q_len, batch_size)
+        @test size(α_self) == (q_len, q_len, nqheads, batch_size)
+
+        # 2-Tuple input (Query, Key=Value)
+        (y_kv, α_kv), _ = gqa((q, k), ps, st)
+        @test size(y_kv) == (embed_dim, q_len, batch_size)
+        @test size(α_kv) == (kv_len, q_len, nqheads, batch_size)
+
+        # 3-Tuple input (Query, Key, Value)
+        (y_qkv, α_qkv), _ = gqa((q, k, v), ps, st)
+        @test size(y_qkv) == (embed_dim, q_len, batch_size)
+        @test size(α_qkv) == (kv_len, q_len, nqheads, batch_size)
+
+        # 4-Tuple input with Causal Mask
+        mask = NNlib.make_causal_mask(q)
+        (y_masked, α_masked), _ = gqa((q, q, q, mask), ps, st)
+        @test size(y_masked) == (embed_dim, q_len, batch_size)
+        @test all(α_masked[2, 1, :, :] .== 0) # Lower triangle mask verification
+    end
+
+    @testset "Numerical Equivalence: Implicit GQA vs. Manual Expansion" begin
+        embed_dim = 64
+        nqheads = 8
+        nkvheads = 2
+        group_size = nqheads ÷ nkvheads
+        seq_len = 8
+        batch_size = 2
+
+        gqa = GroupQueryAttention(embed_dim; nqheads=nqheads, nkvheads=nkvheads)
+        ps, st = Lux.setup(rng, gqa)
+        x = randn(Float32, embed_dim, seq_len, batch_size)
+
+        # Forward pass through custom GQA struct
+        (y_gqa, α_gqa), _ = gqa(x, ps, st)
+
+        # Manual head expansion baseline
+        q_proj, _ = gqa.q_proj(x, ps.q_proj, st.q_proj)
+        k_proj, _ = gqa.k_proj(x, ps.k_proj, st.k_proj)
+        v_proj, _ = gqa.v_proj(x, ps.v_proj, st.v_proj)
+
+        d_head = embed_dim ÷ nqheads
+        q_reshaped = reshape(q_proj, d_head, nqheads, seq_len, batch_size)
+        k_reshaped = reshape(k_proj, d_head, nkvheads, seq_len, batch_size)
+        v_reshaped = reshape(v_proj, d_head, nkvheads, seq_len, batch_size)
+
+        # Physically duplicate Key/Value heads along axis 2
+        k_repeated = repeat(k_reshaped; inner=(1, group_size, 1, 1))
+        v_repeated = repeat(v_reshaped; inner=(1, group_size, 1, 1))
+
+        x_manual, α_manual = LuxLib.scaled_dot_product_attention(
+            q_reshaped, k_repeated, v_repeated; head_dim=1, token_dim=3
+        )
+        x_manual_flat = reshape(x_manual, embed_dim, seq_len, batch_size)
+        y_manual, _ = gqa.out_proj(x_manual_flat, ps.out_proj, st.out_proj)
+
+        @test y_gqa ≈ y_manual atol=1e-5
+        @test α_gqa ≈ α_manual atol=1e-5
+    end
+end
+
+@testset "$mode" for (mode, aType, dev, ongpu) in MODES
+
+    @testset "Autodiff / Gradient Correctness" begin
+        # instantiate GQA ;ayer, input/output dim of 8192, 8 query heads, 2 key/value heads
+        gqa = GroupQueryAttention(64; nqheads=8, nkvheads=2)
+        # initialize layer parameters (ps) and state (st) deterministically using rng
+        ps, st = Lux.setup(rng, gqa) |> dev # moves ps and st from CPU to GPU if dev is a GPU device
+        # generating a dummy input tensor with shape (embed_dim=8192, seq_len=8, batch_size=2)
+        x = randn(Float32, 64, 8, 2) |> aType # converts x to the appropriate array type (CPU or GPU) based on aType
+
+
+        # define a scalar loss function suitable for reverse-mode AD
+        # 1. model(x, ps, st) return a tuple ((y, α), st_new) where y is the output tensor and α is the attention scores
+        # 2. first 'first(...)' extracts '(y, α)' from the tuple returned by model(x, ps, st)
+        # 3. second 'first(...)' extracts 'y' from the tuple '(y, α)'
+        # 4. sum(abs2, ...) computes the sum of squared elements of L2 norm
+        # loss_fn(model, x, ps, st) = sum(abs2, first(model(x, ps, st)))
+        function loss_fn(model, x, ps, st)
+            (y, α), _ = model(x, ps, st)
+            return sum(abs2, y) + sum(abs2, α)
+        end
+
+        # compares gradients computed via Zygote/ForwardDiff against numerical finite differences between specified tolerances
+        @test_gradients(loss_fn, gqa, x, ps, st; 
+                        backends=[AutoZygote(), AutoForwardDiff()],
+                        atol=1e-3, rtol=1e-3)
+
+        @testset "Precision Support" begin
+            gqa = GroupQueryAttention(64; nqheads=8, nkvheads=2)
+            ps, st = Lux.setup(rng, gqa)
+            x = randn(Float32, 64, 8, 2)
+
+            # 1. Standard Float32 pass
+            (y32, α32), _ = gqa(x, ps, st)
+            @test eltype(y32) == Float32
+
+            # 2. Float16 precision pass using Lux.f16
+            ps_f16 = Lux.f16(ps)
+            st_f16 = Lux.f16(st)
+            x_f16  = Float16.(x)
+
+            (y16, α16), _ = gqa(x_f16, ps_f16, st_f16)
+            @test eltype(y16) == Float16
+            @test eltype(α16) == Float16
+        end
+
+
+        using JET
+
+        @testset "Allocation Bound Verification" begin
+            st_test = Lux.testmode(st)
+
+            # Warmup pass to trigger JIT compilation (crucial!)
+            gqa(x, ps, st_test)
+
+            # Base.@allocated measures exact bytes allocated by the expression
+            allocs = @allocated gqa(x, ps, st_test)
+
+            # Verify standard intermediate array creation stays within functional bounds
+            @test allocs < 65_000
+        end
+
+        @testset "Autoregressive Shape Verification" begin
+            q_single = randn(Float32, 64, 1, 2)   # Single new query token
+            k_past   = randn(Float32, 64, 128, 2) # 128 cached KV tokens
+            v_past   = randn(Float32, 64, 128, 2)
+            
+            (y_dec, α_dec), _ = gqa((q_single, k_past, v_past), ps, st)
+            @test size(y_dec) == (64, 1, 2)
+            @test size(α_dec) == (128, 1, 8, 2) # (kv_len, q_len, nqheads, batch)
+        end
+
+    end
+end
+
+

--- a/test/core_layers/attention_tests.jl
+++ b/test/core_layers/attention_tests.jl
@@ -1,14 +1,4 @@
-using Pkg
-ENV["GROUP"] = "CPU"  # Options are usually "CPU", "CUDA", "AMDGPU", "Metal", or "ALL"
-ENV["AUTODIFF_BACKENDS"] = "Zygote,ForwardDiff"
-Pkg.activate("test")
-Pkg.instantiate()
 using NNlib
-using Test
-using Lux
-using LuxLib
-using Random
-
 
 include("../shared_testsetup.jl")
 
@@ -74,177 +64,79 @@ include("../shared_testsetup.jl")
     end
 end
 
+@testset "GroupQueryAttention" begin
+    rng = StableRNG(12345)
 
-
-rng = Random.default_rng()
-Random.seed!(rng, 42)
-
-@testset "GroupQueryAttention Implementation Tests" begin
-
-    @testset "Constructor & Assertion Guardrails" begin
-        # 1. Valid GQA construction
-        gqa = GroupQueryAttention(64; nqheads=8, nkvheads=2)
-        @test gqa isa AbstractLuxContainerLayer
-        @test gqa.nqheads == 8
-        @test gqa.nkvheads == 2
-
-        # 2. Invalid head ratio: nqheads (8) not divisible by nkvheads (3)
-        @test_throws AssertionError GroupQueryAttention(64; nqheads=8, nkvheads=3)
-
-        # 3. Invalid dimension: qk_dim (64) not divisible by nqheads (10)
-        @test_throws AssertionError GroupQueryAttention(64; nqheads=10, nkvheads=2)
+    function loss(model, x, ps, st)
+        y, α = first(model(x, ps, st))
+        return sum(abs2, y) + sum(abs2, α)
     end
 
-    @testset "Shape Verification & Input Signatures" begin
-        embed_dim = 64
-        q_len = 12
-        kv_len = 18
-        batch_size = 4
-        nqheads = 8
-        nkvheads = 2
+    @testset "$mode" for (mode, aType, dev, ongpu) in MODES
+        dim, nqheads, nkvheads, batch_size, len = 8, 4, 2, 5, 3
 
-        gqa = GroupQueryAttention(embed_dim; nqheads=nqheads, nkvheads=nkvheads)
-        ps, st = Lux.setup(rng, gqa)
+        gqa = GroupQueryAttention(dim; nqheads, nkvheads)
 
-        q = randn(Float32, embed_dim, q_len, batch_size)
-        k = randn(Float32, embed_dim, kv_len, batch_size)
-        v = randn(Float32, embed_dim, kv_len, batch_size)
+        q = rand(Float32, (dim, len, batch_size)) |> aType
+        k = rand(Float32, (dim, len, batch_size)) |> aType
+        v = rand(Float32, (dim, len, batch_size)) |> aType
 
-        # Single input (Self-Attention)
-        (y_self, α_self), st_self = gqa(q, ps, st)
-        @test size(y_self) == (embed_dim, q_len, batch_size)
-        @test size(α_self) == (q_len, q_len, nqheads, batch_size)
+        ps, st = Lux.setup(rng, gqa) |> dev
 
-        # 2-Tuple input (Query, Key=Value)
-        (y_kv, α_kv), _ = gqa((q, k), ps, st)
-        @test size(y_kv) == (embed_dim, q_len, batch_size)
-        @test size(α_kv) == (kv_len, q_len, nqheads, batch_size)
+        (y, α), stₙ = gqa((q, k, v), ps, st) # a standard full cross-attention forward pass with distinct query, key, and value tensors.
+        @test y isa aType{Float32,3} # asserts that output tensor y is a 3D array matching the target device array type (e.g., CuArray on GPU).
+        @test size(y) == (dim, len, batch_size) # Verifies output tensor dimensions match (d_out, seq_len,batch).
+        @test α isa aType{Float32,4} 
+        @test size(α) == (len, len, nqheads, batch_size) # Verifies that attention scores maintain n_qheads, dimensions, proving key/value heads were broadcast correctly across query groups.
+       
+        @test gqa((q, k, v), ps, stₙ)[1][1] ≈ y # Validates functional state propagation—passing the updated layer state stₙ back into the layer produces identical output values (y) without parameter mutation side effects.
 
-        # 3-Tuple input (Query, Key, Value)
-        (y_qkv, α_qkv), _ = gqa((q, k, v), ps, st)
-        @test size(y_qkv) == (embed_dim, q_len, batch_size)
-        @test size(α_qkv) == (kv_len, q_len, nqheads, batch_size)
+        @testset "self-attention" begin
+            (y1, α1), stₙ = gqa(q, ps, st)
+            (y2, α2), stₙ = gqa((q, q, q), ps, stₙ)
+            @test y1 ≈ y2
+            @test α1 ≈ α2
+        end
 
-        # 4-Tuple input with Causal Mask
-        mask = NNlib.make_causal_mask(q)
-        (y_masked, α_masked), _ = gqa((q, q, q, mask), ps, st)
-        @test size(y_masked) == (embed_dim, q_len, batch_size)
-        @test all(α_masked[2, 1, :, :] .== 0) # Lower triangle mask verification
-    end
+        @testset "key and value are the same" begin
+            (y1, α1), stₙ = gqa((q, k, k), ps, st)
+            (y2, α2), stₙ = gqa((q, k), ps, stₙ)
+            @test y1 ≈ y2
+            @test α1 ≈ α2
+        end
 
-    @testset "Numerical Equivalence: Implicit GQA vs. Manual Expansion" begin
-        embed_dim = 64
-        nqheads = 8
-        nkvheads = 2
-        group_size = nqheads ÷ nkvheads
-        seq_len = 8
-        batch_size = 2
+        @testset "change dims" begin
+            dims = 8 => 12 => 6
+            nheads_q, nheads_kv = 4, 2
+            gqa2 = GroupQueryAttention(dims; nqheads=nheads_q, nkvheads=nheads_kv)
+            ps2, st2 = Lux.setup(rng, gqa2) |> dev
+            (y2, _), st2ₙ = gqa2((q, k, v), ps2, st2)
+            @test size(y2) == (dims.second.second, len, batch_size)
+        end
 
-        gqa = GroupQueryAttention(embed_dim; nqheads=nqheads, nkvheads=nkvheads)
-        ps, st = Lux.setup(rng, gqa)
-        x = randn(Float32, embed_dim, seq_len, batch_size)
+        @testset "mask" begin
+            mask = NNlib.make_causal_mask(q)
+            (y, α), stₙ = gqa((q, q, q, mask), ps, st)
+            @test all(α[2, 1, :, :] .== 0) # Verifies that position 2 cannot attend to position 1, forcing attention weight probabilities to strictly zero out past causal boundaries.
+            @test α[:, :, 1, 1] ≈ triu(α[:, :, 1, 1])
+        end
 
-        # Forward pass through custom GQA struct
-        (y_gqa, α_gqa), _ = gqa(x, ps, st)
+        @testset "MHA Parity (nqheads == nkvheads)" begin
+            nheads = 4
+            mha = MultiHeadAttention(dim; nheads)
+            gqa_mha = GroupQueryAttention(dim; nqheads=nheads, nkvheads=nheads) # Forces n_qheads=n_kvheads, where GQA degenerates structurally into standard MHA.
 
-        # Manual head expansion baseline
-        q_proj, _ = gqa.q_proj(x, ps.q_proj, st.q_proj)
-        k_proj, _ = gqa.k_proj(x, ps.k_proj, st.k_proj)
-        v_proj, _ = gqa.v_proj(x, ps.v_proj, st.v_proj)
+            # Identical parameter tree layout allows passing shared parameters directly
+            ps_shared, st_mha = Lux.setup(rng, mha) |> dev
+            _, st_gqa = Lux.setup(rng, gqa_mha) |> dev
 
-        d_head = embed_dim ÷ nqheads
-        q_reshaped = reshape(q_proj, d_head, nqheads, seq_len, batch_size)
-        k_reshaped = reshape(k_proj, d_head, nkvheads, seq_len, batch_size)
-        v_reshaped = reshape(v_proj, d_head, nkvheads, seq_len, batch_size)
+            (y_mha, α_mha), _ = mha((q, k, v), ps_shared, st_mha)
+            (y_gqa, α_gqa), _ = gqa_mha((q, k, v), ps_shared, st_gqa)
 
-        # Physically duplicate Key/Value heads along axis 2
-        k_repeated = repeat(k_reshaped; inner=(1, group_size, 1, 1))
-        v_repeated = repeat(v_reshaped; inner=(1, group_size, 1, 1))
+            @test y_gqa ≈ y_mha
+            @test α_gqa ≈ α_mha
+        end
 
-        x_manual, α_manual = LuxLib.scaled_dot_product_attention(
-            q_reshaped, k_repeated, v_repeated; head_dim=1, token_dim=3
-        )
-        x_manual_flat = reshape(x_manual, embed_dim, seq_len, batch_size)
-        y_manual, _ = gqa.out_proj(x_manual_flat, ps.out_proj, st.out_proj)
-
-        @test y_gqa ≈ y_manual atol=1e-5
-        @test α_gqa ≈ α_manual atol=1e-5
+        @test_gradients(loss, gqa, (q, k, v), ps, st; atol=1.0f-3, rtol=1.0f-3)
     end
 end
-
-@testset "$mode" for (mode, aType, dev, ongpu) in MODES
-
-    @testset "Autodiff / Gradient Correctness" begin
-        # instantiate GQA ;ayer, input/output dim of 8192, 8 query heads, 2 key/value heads
-        gqa = GroupQueryAttention(64; nqheads=8, nkvheads=2)
-        # initialize layer parameters (ps) and state (st) deterministically using rng
-        ps, st = Lux.setup(rng, gqa) |> dev # moves ps and st from CPU to GPU if dev is a GPU device
-        # generating a dummy input tensor with shape (embed_dim=8192, seq_len=8, batch_size=2)
-        x = randn(Float32, 64, 8, 2) |> aType # converts x to the appropriate array type (CPU or GPU) based on aType
-
-
-        # define a scalar loss function suitable for reverse-mode AD
-        # 1. model(x, ps, st) return a tuple ((y, α), st_new) where y is the output tensor and α is the attention scores
-        # 2. first 'first(...)' extracts '(y, α)' from the tuple returned by model(x, ps, st)
-        # 3. second 'first(...)' extracts 'y' from the tuple '(y, α)'
-        # 4. sum(abs2, ...) computes the sum of squared elements of L2 norm
-        # loss_fn(model, x, ps, st) = sum(abs2, first(model(x, ps, st)))
-        function loss_fn(model, x, ps, st)
-            (y, α), _ = model(x, ps, st)
-            return sum(abs2, y) + sum(abs2, α)
-        end
-
-        # compares gradients computed via Zygote/ForwardDiff against numerical finite differences between specified tolerances
-        @test_gradients(loss_fn, gqa, x, ps, st; 
-                        backends=[AutoZygote(), AutoForwardDiff()],
-                        atol=1e-3, rtol=1e-3)
-
-        @testset "Precision Support" begin
-            gqa = GroupQueryAttention(64; nqheads=8, nkvheads=2)
-            ps, st = Lux.setup(rng, gqa)
-            x = randn(Float32, 64, 8, 2)
-
-            # 1. Standard Float32 pass
-            (y32, α32), _ = gqa(x, ps, st)
-            @test eltype(y32) == Float32
-
-            # 2. Float16 precision pass using Lux.f16
-            ps_f16 = Lux.f16(ps)
-            st_f16 = Lux.f16(st)
-            x_f16  = Float16.(x)
-
-            (y16, α16), _ = gqa(x_f16, ps_f16, st_f16)
-            @test eltype(y16) == Float16
-            @test eltype(α16) == Float16
-        end
-
-
-        using JET
-
-        @testset "Allocation Bound Verification" begin
-            st_test = Lux.testmode(st)
-
-            # Warmup pass to trigger JIT compilation (crucial!)
-            gqa(x, ps, st_test)
-
-            # Base.@allocated measures exact bytes allocated by the expression
-            allocs = @allocated gqa(x, ps, st_test)
-
-            # Verify standard intermediate array creation stays within functional bounds
-            @test allocs < 65_000
-        end
-
-        @testset "Autoregressive Shape Verification" begin
-            q_single = randn(Float32, 64, 1, 2)   # Single new query token
-            k_past   = randn(Float32, 64, 128, 2) # 128 cached KV tokens
-            v_past   = randn(Float32, 64, 128, 2)
-            
-            (y_dec, α_dec), _ = gqa((q_single, k_past, v_past), ps, st)
-            @test size(y_dec) == (64, 1, 2)
-            @test size(α_dec) == (128, 1, 8, 2) # (kv_len, q_len, nqheads, batch)
-        end
-
-    end
-end
-
-


### PR DESCRIPTION
### Summary
This PR introduces the `GroupedQueryAttention` (GQA) layer to `Lux.jl`, providing support for memory-efficient attention mechanisms common in modern LLM architectures.

### Key Changes
* **Implementation:** Added the `GroupedQueryAttention` layer, supporting flexible query and key-value head configurations.
* **Documentation:** Included comprehensive docstrings with layer parameters, state descriptions, and runnable usage examples.
* **Unit Tests:** Added tests covering forward pass execution, output dimensions, and parameter/state initialization.

### Verification
* Verified layer outputs and dimensions across varied batch sizes and sequence lengths.
* Verified GQA output parity against equivalent MQA configurations.